### PR TITLE
Declare esprima as dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "es6-object-assign": "~1.1.0",
     "es6-promise": "^4.1.0",
     "escodegen": "^1.8.1",
+    "esprima": "^4.0.0",
     "findup": "^0.1.5",
     "function.name-polyfill": "^1.0.5",
     "github-slugger": "^1.1.3",

--- a/src/rsg-components/Preview/Preview.js
+++ b/src/rsg-components/Preview/Preview.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { transform } from 'buble';
 import PlaygroundError from 'rsg-components/PlaygroundError';
-import esprima from 'esprima';
+import { parse } from 'esprima';
 import Vue from 'vue';
 
 /* eslint-disable react/no-multi-comp */
@@ -129,7 +129,7 @@ export default class Preview extends Component {
 			if (compuse.vueComponent) {
 				configComponent = this.compileCode(compuse.vueComponent);
 			}
-			syntaxTree = esprima.parse(compuse.js);
+			syntaxTree = parse(compuse.js);
 			listVars = getVars(syntaxTree);
 		} catch (err) {
 			this.handleError(err);


### PR DESCRIPTION
When I use vue-styleguidist to create a client-side npm-project when I declare styleguidist as a dependency, and because of `esprima` package is not specified explicitly in `package.json` - it gets resolved differently. I did see 2.7.3 and 4.0.0 versions in both of my yarn and npm lockfiles, but yarn resolves to 2.7.3 while npm to 4.0.0 in first-level `node_modules` folder. And Esprima at 2.7.3 used UMD, and for that, syntax like
```javascript
import esprima from 'esprima'
esprima.parse() // -- is ok
```

But for 4.0.0 Esprima migrated to Typescript (I think they migrated in 3.0.0 version), and it uses ES modules. And for that, former usage of module would break (because of how named exports). 
```javascript
import { parse } from 'esprima'
parse() // -- this would work
```

I tried to verify if it works, but because of #15 I couldn't verify it 😅.


Hope everything's clear, feel free to ask anything or edit PR!