### PR TITLE
fix: wrong error when a non-vue file is in config

### DIFF
--- a/loaders/utils/processComponent.js
+++ b/loaders/utils/processComponent.js
@@ -40,10 +40,8 @@ module.exports = function processComponent(filepath, config) {
 	if (isVueFile(filepath)) {
 		props = requireIt(`!!${vueDocLoader}!${filepath}`);
 	} else {
-		const message =
-			`Error when parsing ${filepath}:\n\n` +
-			'Only can parse files .vue:\n' +
-			logger.debug(message);
+		const message = `Error when parsing ${filepath}:\n\n` + 'Only can parse files .vue:\n';
+		logger.debug(message);
 		throw new Error(message);
 	}
 	const examplesFile = config.getExampleFilename(filepath);


### PR DESCRIPTION
Error "message is not defined" is thrown when the styleguide.config.js includes a "component" that is not a .vue file.

It's supposed to throw `Error when parsing ${filepath}:\n\n` + 'Only can parse files .vue:\n' (which it does after this fix)