### PR TITLE
Fixed opn URL when supplying --open CLI option

### DIFF
--- a/bin/styleguidist.js
+++ b/bin/styleguidist.js
@@ -126,7 +126,7 @@ function commandServer() {
 			const urls = webpackDevServerUtils.prepareUrls(isHttps ? 'https' : 'http', host, port);
 			printInstructions(urls.localUrlForTerminal, urls.lanUrlForTerminal);
 			if (argv.open) {
-				opn(urls.localUrlForTerminal.slice(0, -1));
+				opn(urls.localUrlForBrowser);
 			}
 		}
 	});


### PR DESCRIPTION
The `urls.localUrlForBrowser` is the string we want to supply to `opn`.