### PR TITLE
Fixes font colors in examples being overwritten in Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jss-compose": "^5.0.0",
     "jss-default-unit": "^8.0.0",
     "jss-global": "^3.0.0",
-    "jss-isolate": "5.0.0",
+    "jss-isolate": "^5.1.0",
     "jss-nested": "^6.0.1",
     "leven": "^2.1.0",
     "listify": "^1.0.0",


### PR DESCRIPTION
We’ve been running into this issue with the latest versions of Vue StyleGuidist and tracked it down to be related to this same issue on React Styleguidist: https://github.com/styleguidist/react-styleguidist/issues/739 

I created a reduced test case in Codepen that replicates the issue in Safari: https://codepen.io/viljamis/pen/XZEaee

Updating jss-isolate to the latest (5.1.0) fixes the issue as it includes a fix for this Safari bug.