### PR TITLE
Fixes scrolling in Safari (and a few other browsers) when using navigation: true

### DIFF
--- a/src/utils/scrollTo.js
+++ b/src/utils/scrollTo.js
@@ -1,5 +1,5 @@
 export default function scrollTo(id) {
-	const element = document.querySelector('html');
+	const element = document.scrollingElement || document.documentElement;
 	let to = 0;
 	if (id) {
 		to = document.getElementById(id).offsetTop;


### PR DESCRIPTION
I noticed that the scrollto functionality is broken in at least desktop Safari when using `navigation: true`. This is caused because the scrolling element in this case in Safari is actually `body` not `html`.

This pull should fix the functionality to work in any modern browser