### PR TITLE
fix: defaultConfig

### DIFF
--- a/scripts/schemas/config.js
+++ b/scripts/schemas/config.js
@@ -1,8 +1,7 @@
 // If you want to access any of these options in React, don’t forget to update CLIENT_CONFIG_OPTIONS array
 // in loaders/styleguide-loader.js
 
-const EXTENSIONS = 'vue';
-const DEFAULT_COMPONENTS_PATTERN = `src/(components|Components)/**/*.{${EXTENSIONS}}`;
+const DEFAULT_COMPONENTS_PATTERN = `src/{components,Components}/**/*.vue`;
 
 const path = require('path');
 const startCase = require('lodash/startCase');
@@ -86,15 +85,7 @@ module.exports = {
 		},
 		example: componentPath => componentPath.replace(/\.jsx?$/, '.examples.md'),
 	},
-	ignore: {
-		type: 'array',
-		default: [
-			'**/__tests__/**',
-			`**/*.test.{${EXTENSIONS}}`,
-			`**/*.spec.{${EXTENSIONS}}`,
-			'**/*.d.ts',
-		],
-	},
+
 	highlightTheme: {
 		type: 'string',
 		default: 'base16-light',


### PR DESCRIPTION
2 issues here:
- since we are using onely one type of files,
glob is consideruing {vue} to be a litteral 
I tried my new glob on http://www.globtester.com and it works with minimatch.
- no test or ignored file needs to be specified since we want All `.vue`