### PR TITLE
Missing babel preset added to Nuxt.js example

### DIFF
--- a/examples/nuxtjs/package.json
+++ b/examples/nuxtjs/package.json
@@ -18,6 +18,7 @@
     "vue-webpack-loaders": "^1.0.8"
   },
   "devDependencies": {
-    "babel-preset-react": "^6.24.1"
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1"
   }
 }


### PR DESCRIPTION
By default while trying to run Nuxt.js example is got these errors:

```
Error: Couldn't find preset "es2015" relative to directory "/Users/igloczek/Sites/temp/vue-styleguidist/examples/nuxtjs"

Warning: Cannot parse src/components/Logo.vue: Error: Error: Couldn't find preset "es2015" relative to directory "/Users/igloczek/Sites/temp/vue-styleguidist/examples/nuxtjs"

It usually means that vue-docgen-api does not understand your source code or when using third-party libraries, try to file an issue here:
https://github.com/vue-styleguidist/vue-docgen-api/issues


Error: Couldn't find preset "es2015" relative to directory "/Users/igloczek/Sites/temp/vue-styleguidist/examples/nuxtjs"

Warning: Cannot parse src/components/CounterButton/CounterButton.vue: Error: Error: Couldn't find preset "es2015" relative to directory "/Users/igloczek/Sites/temp/vue-styleguidist/examples/nuxtjs"

It usually means that vue-docgen-api does not understand your source code or when using third-party libraries, try to file an issue here:
https://github.com/vue-styleguidist/vue-docgen-api/issues

 FAIL  Failed to compile

./src/components/Logo.vue
Module build failed: Error: Couldn't find preset "es2015" relative to directory "/Users/igloczek/Sites/temp/vue-styleguidist/examples/nuxtjs"
    at Array.map (<anonymous>)
./src/components/CounterButton/CounterButton.vue
Module build failed: Error: Couldn't find preset "es2015" relative to directory "/Users/igloczek/Sites/temp/vue-styleguidist/examples/nuxtjs"
    at Array.map (<anonymous>)
./src/store/index.js
Module build failed: Error: Couldn't find preset "es2015" relative to directory "/Users/igloczek/Sites/temp/vue-styleguidist/examples/nuxtjs"
    at Array.map (<anonymous>)
```

Adding `babel-preset-es2015` solves this problem. 