### PR TITLE
fix(editor): html was rendered automaticaly by mistake

### DIFF
--- a/loaders/utils/getExamples.js
+++ b/loaders/utils/getExamples.js
@@ -14,12 +14,12 @@ const examplesLoader = path.resolve(__dirname, '../examples-loader.js');
  */
 module.exports = function getExamples(examplesFile, displayName, defaultExample) {
 	if (examplesFile && fs.existsSync(examplesFile)) {
-		return requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx|html!${examplesFile}`);
+		return requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx!${examplesFile}`);
 	}
 
 	if (defaultExample) {
 		return requireIt(
-			`!!${examplesLoader}?componentName=${displayName}&customLangs=vue|js|jsx|html!${defaultExample}`
+			`!!${examplesLoader}?componentName=${displayName}&customLangs=vue|js|jsx!${defaultExample}`
 		);
 	}
 

--- a/loaders/utils/getProps.js
+++ b/loaders/utils/getProps.js
@@ -105,7 +105,7 @@ module.exports = function getProps(doc, filepath) {
 		}
 
 		if (exampleFileExists) {
-			doc.example = requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx|html!${exampleFile}`);
+			doc.example = requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx!${exampleFile}`);
 			delete doc.doclets.example;
 		}
 	} else {

--- a/loaders/utils/getSections.js
+++ b/loaders/utils/getSections.js
@@ -48,7 +48,7 @@ function processSection(section, config, parentDepth) {
 		if (!fs.existsSync(contentAbsolutePath)) {
 			throw new Error(`Styleguidist: Section content file not found: ${contentAbsolutePath}`);
 		}
-		content = requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx|html!${contentAbsolutePath}`);
+		content = requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx!${contentAbsolutePath}`);
 	}
 
 	let sectionDepth;

--- a/loaders/vuedoc-loader.js
+++ b/loaders/vuedoc-loader.js
@@ -29,12 +29,12 @@ module.exports = function(source) {
 
 		const componentVueDoc = getComponentVueDoc(source, file);
 		if (componentVueDoc) {
-			docs.example = requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx|html!${file}`);
+			docs.example = requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx!${file}`);
 		} else if (docs.tags) {
 			const examples = docs.tags.examples;
 			if (examples) {
 				const examplePath = examples[examples.length - 1].description;
-				docs.example = requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx|html!${examplePath}`);
+				docs.example = requireIt(`!!${examplesLoader}?customLangs=vue|js|jsx!${examplePath}`);
 			}
 		}
 		if (docs.props) {


### PR DESCRIPTION
When I tried to use react-stykleguidist exampl-loader in order to lower the amount of code we are dealing with, I involuntarily changed the behaviour. Here is a quick fix of it ;).

closes #234