### PR TITLE
fix: prop render needs to be vue oriented, not react oriented

### DIFF
--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Group from 'react-group';
-import objectToString from 'javascript-stringify';
 import Arguments from 'rsg-components/Arguments';
 import Argument from 'rsg-components/Argument';
 import Code from 'rsg-components/Code';
@@ -108,8 +107,8 @@ function renderDefault(prop) {
 	// Workaround for issue https://github.com/reactjs/react-docgen/issues/221
 	// If prop has defaultValue it can not be required
 	if (prop.defaultValue) {
-		if (prop.type || prop.flowType) {
-			const propName = prop.type ? prop.type.name : prop.flowType.type;
+		if (prop.type) {
+			const propName = prop.type.name;
 
 			if (defaultValueBlacklist.indexOf(prop.defaultValue.value) > -1) {
 				return <Code>{showSpaces(unquote(prop.defaultValue.value))}</Code>;
@@ -124,28 +123,6 @@ function renderDefault(prop) {
 						Function
 					</Text>
 				);
-			} else if (propName === 'shape' || propName === 'object') {
-				try {
-					// We eval source code to be able to format the defaultProp here. This
-					// can be considered safe, as it is the source code that is evaled,
-					// which is from a known source and safe by default
-					// eslint-disable-next-line no-eval
-					const object = eval(`(${prop.defaultValue.value})`);
-					return (
-						<Text size="small" color="light" underlined title={objectToString(object, null, 2)}>
-							Shape
-						</Text>
-					);
-				} catch (e) {
-					// eval will throw if it contains a reference to a property not in the
-					// local scope. To avoid any breakage we fall back to rendering the
-					// prop without any formatting
-					return (
-						<Text size="small" color="light" underlined title={prop.defaultValue.value}>
-							Shape
-						</Text>
-					);
-				}
 			}
 		}
 


### PR DESCRIPTION
Rendering of props should not try to resolve pop-types or shapes as ghos do not exist in vuejs. instead, we might want to test vue-types validations but this is another story.