### PR TITLE
fix(plugin/ui): mountPointId link was wrong

### DIFF
--- a/packages/vue-cli-plugin-styleguidist/ui/config.js
+++ b/packages/vue-cli-plugin-styleguidist/ui/config.js
@@ -114,7 +114,7 @@ function onRead({ data }) {
 						type: 'input',
 						message: 'Mount Point ID',
 						description: 'The ID of a DOM element where Styleguidist mounts.',
-						link: 'https://vue-styleguidist.github.io/Configuration.html#showsidebar',
+						link: 'https://vue-styleguidist.github.io/Configuration.html#mountpointid',
 						default: 'rsg-root',
 						value: styleguide.mountPointId
 					},


### PR DESCRIPTION
Ctrl-C Ctrl-V Driven Development (CCCVDD) ;-)