### PR TITLE
Fix spelling and grammar in docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,7 @@ yarn
 
 ## Dependency architecture
 
-In this monorepo, `vue-cli-plugin-styleguidist` depends on `vue-styleguidist` which in turn depends on `vue-docgen-api`. So if you change something in vue-docgen-api, a new version of each module is going to be delivered. Whereas if you only change something only in the plugin, nonly the plugin will be delivered.
+In this monorepo, `vue-cli-plugin-styleguidist` depends on `vue-styleguidist` which in turn depends on `vue-docgen-api`. So if you change something in vue-docgen-api, a new version of each module is going to be delivered. Whereas if you only change something only in the plugin, only the plugin will be delivered.
 
 ## Testing Tips
 
@@ -53,7 +53,7 @@ Allows you to run the examples against your local version of styleguidist. An ex
 yarn start customised
 ```
 
-This command will run the `customised` example. It will look for `examples/customised/styleguide.config.js` and run styleguidist on it. You can ommit the last param and do just `yarn start` to run the basic example.
+This command will run the `customised` example. It will look for `examples/customised/styleguide.config.js` and run styleguidist on it. You can omit the last param and do just `yarn start` to run the basic example.
 
 ### yarn build
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -135,7 +135,7 @@ The scripts are transformed from es6 or jsx to es5 using buble. The names of the
 
 ### Render example
 
-First make sure that the mount point is ready and save it in a variable Second prepare the component by executing the funciton created above `exampleComponent()` And finally instanciate vue to mount our made up component in the mounting point
+First make sure that the mount point is ready and save it in a variable Second prepare the component by executing the funciton created above `exampleComponent()` And finally instantiate vue to mount our made up component in the mounting point
 
 ### Hot Reload
 

--- a/docs/Docgen.md
+++ b/docs/Docgen.md
@@ -86,7 +86,7 @@ Script and template have 2 different AST structure. Makes sense that they have d
 
 ### Script Handlers
 
-To handle scripts, we can registrer them this way. Each handler is a JavaScript function following this prototype.
+To handle scripts, we can register them this way. Each handler is a JavaScript function following this prototype.
 
 ```ts
 export default function handler(

--- a/docs/Documenting.md
+++ b/docs/Documenting.md
@@ -478,7 +478,7 @@ export default {
 
 ## TypeScript, Flow and Class-style Components
 
-Vue styleguidist understands TypeScript & Flow anotations. Write components in a typed language, types are documented automatically. It is compatible with class style components as well.
+Vue styleguidist understands TypeScript & Flow annotations. Write components in a typed language, types are documented automatically. It is compatible with class style components as well.
 
 ```ts
 import { Component, Prop, Vue } from 'vue-property-decorator'

--- a/docs/VueCLI3doc.md
+++ b/docs/VueCLI3doc.md
@@ -8,6 +8,6 @@ The vue environment created packs its own set of features. If you want to add st
 vue add styleguidist
 ```
 
-Vue Styleguidist will configure itslef and add a couple examples to get you started. It will imediately set up the webpack config the hmr and a nice styleguide for you to use. You can still modify the `styleguide.config.js` to make the styleguide look even better.
+Vue Styleguidist will configure itself and add a couple examples to get you started. It will immediately set up the webpack config the hmr and a nice styleguide for you to use. You can still modify the `styleguide.config.js` to make the styleguide look even better.
 
 /!\ NOTA /!\ If you wish to use styleguidist with the CLI but without the plugin, you might have to remove the HMR from the CLI itself. If you do not it might just end up on an infinite HMR loop like in [issue 290](https://github.com/vue-styleguidist/vue-styleguidist/issues/290)

--- a/docs/templates/Examples.md.ejs
+++ b/docs/templates/Examples.md.ejs
@@ -1,7 +1,7 @@
 # Examples
 
 In the [repository](https://github.com/vue-styleguidist/vue-styleguidist/), 
-There is a few example styleguides. Each tryes to demonstrate one key aspect of what you can do with the library.
+there are a few example styleguides. Each tries to demonstrate one key aspect of what you can do with the library.
 Check out the github links to see how it's done.
 
 <!-- toc -->


### PR DESCRIPTION
Fix some spelling and grammar errors in the documentation