### PR TITLE
Fix broken link to view editorConfig option

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -177,7 +177,7 @@ module.exports = {
 
 #### `editorConfig`
 
-Type: `Object`, default: [scripts/schemas/config.js](https://github.com/vue-styleguidist/vue-styleguidist/tree/master/scripts/schemas/config.js#L96)
+Type: `Object`, default: [scripts/schemas/config.js](https://github.com/vue-styleguidist/vue-styleguidist/tree/master/packages/vue-styleguidist/scripts/schemas/config.js#L96)
 
 Source code editor options, see [CodeMirror docs](https://codemirror.net/doc/manual.html#config) for all available options.
 


### PR DESCRIPTION
# What
Link in docs to `editorConfig` option is broken. Path has changed