### PR TITLE
allow vue code blocks without documented component

### DIFF
--- a/packages/vue-styleguidist/src/rsg-components/Preview/Preview.js
+++ b/packages/vue-styleguidist/src/rsg-components/Preview/Preview.js
@@ -77,8 +77,8 @@ class Preview extends Component {
 
 		const { code, vuex, component, renderRootJsx } = this.props
 
-		const documentedComponent = component.module.default || component.module
-		component.displayName = cleanComponentName(this.props.component.name)
+		const documentedComponent = component.module && component.module.default || component.module
+		component.displayName = cleanComponentName(this.props.component.name || "")
 		if (!code) {
 			return
 		}


### PR DESCRIPTION
I have a usecase where I want to use a vue code block in a markdown file without any Vue component associated to it. My usecase is to demonstrate a UI library that comes with a base stylesheet that applies to standard HTML elements, in addition to some custom Vue components. So I have a `typography.md` file with this block:

```
```jsx
<div>
<h1>Heading 1: bold, 250% (2.5rem)</h1>
<h2>Heading 2: 233% (2.33rem)</h2>
<h3>Heading 3: 200% (2rem)</h3>
<h4>Heading 4: 150% (1.5rem)</h4>
<h5>Heading 5: 133% (1.33rem)</h5>
<h6>Heading 6: 120% (1.2rem)</h6>
<p>Regular text content</p>
</div>
\```
```

Directly using HTML in the markdown is not possible, because the documentation styles of styleguidist would override the library styles. So I need the Preview component to get the isolated styles. Also, being able to switch to the code is pretty nice.

Using "vue-cli-plugin-styleguidist": "^3.13.1", this usecase cause an exception in the Preview component code. These small changes fix the issue and let me use the Preview component without any documented component actually assigned to the page.