### PR TITLE
Try absolute require.resolve and fix path joining

### DIFF
--- a/packages/vue-docgen-api/src/utils/resolvePathFrom.ts
+++ b/packages/vue-docgen-api/src/utils/resolvePathFrom.ts
@@ -24,10 +24,15 @@ export default function resolvePathFrom(path: string, from: string[]): string {
 			}
 		}
 		if (!finalPath.length) {
-			try {
-				finalPath = require.resolve(join(from[0], `${path}${s}`))
-			} catch (e) {
-				// eat the error
+			for (let i = 0; i < from.length; i++) {
+				try {
+					finalPath = require.resolve(join(from[i], `${path}${s}`));
+					if (finalPath.length) {
+						break;
+					}
+				} catch (e) {
+					// eat the error
+				}
 			}
 		}
 	})

--- a/packages/vue-docgen-api/src/utils/resolvePathFrom.ts
+++ b/packages/vue-docgen-api/src/utils/resolvePathFrom.ts
@@ -1,3 +1,5 @@
+const { join } = require('path');
+
 const SUFFIXES = ['', '.js', '.ts', '.vue', '.jsx', '.tsx']
 
 export default function resolvePathFrom(path: string, from: string[]): string {
@@ -14,9 +16,16 @@ export default function resolvePathFrom(path: string, from: string[]): string {
 		}
 		if (!finalPath.length) {
 			try {
-				finalPath = require.resolve(`${path}/index${s}`, {
+				finalPath = require.resolve(join(path, `index${s}`), {
 					paths: from
 				})
+			} catch (e) {
+				// eat the error
+			}
+		}
+		if (!finalPath.length) {
+			try {
+				finalPath = require.resolve(join(from[0], `${path}${s}`))
 			} catch (e) {
 				// eat the error
 			}


### PR DESCRIPTION
We are working with [Bazel](https://bazel.build/) which overrides the default nodejs require mechanisms as Bazel manages external dependencies itself and sets `node_modules` up differently. As a result we are getting some issues here with `vue-docgen-api` not finding some of our imported files. Just trying `require.resolve` as a fallback with an absolute path fixes the issue. While I was at it I also fixed the other path joining in this file.

Would be super helpful if we could get this in. Thanks!