### PR TITLE
feat: make mimimizing optional to optimize build time

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -235,6 +235,12 @@ export default {
 
 > **Note** This can be done as well using a `new Vue()` script
 
+## `minimize`
+
+Type: `boolean`, defaults: `true`
+
+If you wish to remove minimization from the build process to help with debugging or to accelate netlify build time on PR, turn this one off.
+
 ## `mountPointId`
 
 Type: `string`, defaults: `rsg-root`

--- a/examples/basic/styleguide.config.js
+++ b/examples/basic/styleguide.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	title: 'Vue Styleguidist basic',
 	components: 'src/components/**/[A-Z]*.vue',
 	defaultExample: true,
+	minimize: false,
 	ribbon: {
 		text: 'Back to examples',
 		url: 'https://vue-styleguidist.github.io/Examples.html'

--- a/packages/vue-cli-plugin-styleguidist/ui/config.js
+++ b/packages/vue-cli-plugin-styleguidist/ui/config.js
@@ -62,7 +62,8 @@ function onRead({ data }) {
 					'mountPointId',
 					'ribbon',
 					'styleguideDir',
-					'assetsDir'
+					'assetsDir',
+					'minimize'
 				]
 					.map(key => filteredSchema[key])
 					.filter(p => !!p)

--- a/packages/vue-styleguidist/scripts/make-webpack-config.js
+++ b/packages/vue-styleguidist/scripts/make-webpack-config.js
@@ -89,29 +89,35 @@ module.exports = function(config, env) {
 	// the HMR has to be loaded after the html plugin.
 	// Hence this piece added last to the list of plugins.
 	if (isProd) {
-		const minimizer = new TerserPlugin({
-			parallel: true,
-			cache: true,
-			terserOptions: {
-				ie8: false,
-				ecma: 5,
-				compress: {
-					keep_fnames: true,
-					warnings: false,
-					/*
+		const optimization = config.minimize
+			? {
+					minimizer: [
+						new TerserPlugin({
+							parallel: true,
+							cache: true,
+							terserOptions: {
+								ie8: false,
+								ecma: 5,
+								compress: {
+									keep_fnames: true,
+									warnings: false,
+									/*
 					 * Disable reduce_funcs to keep Terser from inlining
 					 * Preact's VNode. If enabled, the 'new VNode()' is replaced
 					 * with a anonymous 'function(){}', which is problematic for
 					 * preact-compat, since it extends the VNode prototype to
 					 * accomodate React's API.
 					 */
-					reduce_funcs: false
-				},
-				mangle: {
-					keep_fnames: true
-				}
-			}
-		})
+									reduce_funcs: false
+								},
+								mangle: {
+									keep_fnames: true
+								}
+							}
+						})
+					]
+			  }
+			: { minimize: false }
 		webpackConfig = merge(webpackConfig, {
 			output: {
 				filename: 'build/bundle.[chunkhash:8].js',
@@ -133,9 +139,7 @@ module.exports = function(config, env) {
 						: []
 				)
 			],
-			optimization: {
-				minimizer: [minimizer]
-			}
+			optimization
 		})
 	} else {
 		webpackConfig = merge(webpackConfig, {

--- a/packages/vue-styleguidist/scripts/schemas/config.js
+++ b/packages/vue-styleguidist/scripts/schemas/config.js
@@ -162,6 +162,13 @@ module.exports = {
 	logger: {
 		type: 'object'
 	},
+	minimize: {
+		type: 'boolean',
+		default: true,
+		message: 'Minimize Built Styleguide',
+		description:
+			'If this option is set to false, the styelguidist will not minimize the js at build.'
+	},
 	mountPointId: {
 		message: 'Mount Point ID',
 		description: 'The ID of a DOM element where Styleguidist mounts.',


### PR DESCRIPTION
On Netlify, the build time can go to 12 min. If we make it optional I am convinced it can get it as low as 5 or less. 