### PR TITLE
fix(docgen): get slot and scoped slot description in render without JSX

### DIFF
--- a/packages/vue-docgen-api/src/script-handlers/__tests__/slotHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/__tests__/slotHandler.ts
@@ -126,4 +126,40 @@ describe('render function slotHandler', () => {
 		}
 		expect(mockSlotDescriptor.description).toEqual('Use this slot header')
 	})
+
+	it('should allow describing slots in render', () => {
+        const src = `
+    export default {
+      render: function (createElement) {
+        return createElement(
+        	'div', 
+        	/** @slot Use this slot header */
+        	this.$slots.mySlot
+        )
+      }
+    }
+    `
+        const def = parse(src)
+        if (def) {
+            slotHandler(documentation, def)
+        }
+
+        expect(mockSlotDescriptor.description).toEqual('Use this slot header')
+    })
+
+	it('should allow describing scoped slots in render', () => {
+        const src = `
+    export default {
+      render: function (createElement) {
+        return createElement('div', {}, [/** @slot Use this slot header */this.$scopedSlots.mySlot])
+      }
+    }
+    `
+        const def = parse(src)
+        if (def) {
+            slotHandler(documentation, def)
+        }
+
+        expect(mockSlotDescriptor.description).toEqual('Use this slot header')
+    })
 })


### PR DESCRIPTION
Hello. I found the issue that description for slot is ignored if you try to use pure js without JSX.

Here an example
```
export default {
      render: function (createElement) {
        return createElement(
        	'div', 
        	/** @slot Use this slot header */
        	this.$slots.mySlot
        )
      }
    }
```

Code passes all tests, but i'm not 100% sure it doesn't brake uncovered places

Best wishes,
Sergey