### PR TITLE
fix(codemirror): allow for mulitple words in cm themes

### DIFF
--- a/examples/basic/styleguide.config.js
+++ b/examples/basic/styleguide.config.js
@@ -57,6 +57,9 @@ module.exports = {
 	},
 	usageMode: 'expand',
 	exampleMode: 'expand',
+	editorConfig: {
+		theme: 'solarized dark'
+	},
 	compilerConfig: {
 		target: { ie: 11 }
 	},

--- a/packages/vue-styleguidist/scripts/make-webpack-config.js
+++ b/packages/vue-styleguidist/scripts/make-webpack-config.js
@@ -40,7 +40,9 @@ module.exports = function(config, env) {
 		resolve: {
 			extensions: ['.js', '.jsx', '.json'],
 			alias: {
-				'rsg-codemirror-theme.css': `codemirror/theme/${config.editorConfig.theme}.${'css'}`
+				'rsg-codemirror-theme.css': `codemirror/theme/${
+					config.editorConfig.theme.split(' ')[0]
+				}.css`
 			}
 		},
 		module: {


### PR DESCRIPTION
solarized variants are both stored in the same file
I split the value for the loaded file

Closes #480