### PR TITLE
Edit typos in docs

### DIFF
--- a/docs/docs/Documenting.md
+++ b/docs/docs/Documenting.md
@@ -408,8 +408,8 @@ For instance, if the display name is set as
 
 ```js
 /**
- * @displayName Wonderful Button
- **/
+* @displayName Wonderful Button
+*/
 ```
 
 To reference it in examples, one has to call `<WonderfulButton/>`.


### PR DESCRIPTION
Fixed the example code of displayName.