### PR TITLE
feat: allow jsx in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,25 @@ alt="Chat on Discord">
 
 ## Packages
 
-[vue-styleguidist](packages/vue-styleguidist) will take the results of [vue-docgen-api](packages/vue-docgen-api) and create a website site to showcase and develop components.
+[vue-styleguidist](packages/vue-styleguidist) takes the results of [vue-docgen-api](packages/vue-docgen-api) and creates a website site to showcase and develop components.
 
 [![](https://img.shields.io/npm/v/vue-styleguidist.svg)](https://www.npmjs.com/package/vue-styleguidist) [![](https://img.shields.io/npm/dm/vue-styleguidist.svg)](https://www.npmjs.com/package/vue-styleguidist)
 
 ---
 
-[vue-docgen-api](packages/vue-docgen-api) will parse your vue components and load their documentation in a Javascript object
+[vue-docgen-api](packages/vue-docgen-api) parses vue components and load their documentation in a JavaScript object.
 
 [![](https://img.shields.io/npm/v/vue-docgen-api.svg)](https://www.npmjs.com/package/vue-docgen-api) [![](https://img.shields.io/npm/dm/vue-docgen-api.svg)](https://www.npmjs.com/package/vue-docgen-api)
 
 ---
 
-[vue-cli-plugin-styleguidist](packages/vue-cli-plugin-styleguidist) will configure styleguidist to work smoothly with [vue-cli 3](https://cli.vuejs.org/guide/)
+[vue-inbrowser-compiler](packages/vue-inbrowser-compiler) takes vue components code written in es6 and uses buble to make it compatible with all browser.
+
+[![](https://img.shields.io/npm/v/vue-inbrowser-compiler.svg)](https://www.npmjs.com/package/vue-inbrowser-compiler) [![](https://img.shields.io/npm/dm/vue-inbrowser-compiler.svg)](https://www.npmjs.com/package/vue-inbrowser-compiler)
+
+---
+
+[vue-cli-plugin-styleguidist](packages/vue-cli-plugin-styleguidist) configures vue-styleguidist to work with [vue-cli 3](https://cli.vuejs.org/guide/).
 
 [![](https://img.shields.io/npm/v/vue-cli-plugin-styleguidist.svg)](https://www.npmjs.com/package/vue-cli-plugin-styleguidist) [![](https://img.shields.io/npm/dm/vue-cli-plugin-styleguidist.svg)](https://www.npmjs.com/package/vue-docgen-api)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -168,7 +168,7 @@ Array of [glob pattern](https://github.com/isaacs/node-glob#glob-primer) that sh
 
 > **Note:** You should pass glob patterns, for example, use `**/components/Button.vue` instead of `components/Button.vue`.
 
-## jsxInComponents
+## `jsxInComponents`
 
 Type: `Boolean`, default: `true`
 
@@ -182,6 +182,22 @@ function initDatepicker() {
   })
 }
 ```
+
+## `jsxInExamples`
+
+Type: `Boolean`, default: `false`
+
+If your examples are written in JSX, you will need this flag on.
+
+```jsx
+export default {
+  render() {
+    return <Button />
+  }
+}
+```
+
+> **Note:** When this flag is on, the pseudo-jsx examples will not work anymore. Example should be written with proper vue syntax.
 
 ## `logger`
 

--- a/docs/docs/Documenting.md
+++ b/docs/docs/Documenting.md
@@ -588,3 +588,13 @@ const mockData = require('./mocks');
 ```
 
 > **Note:** If you need a more complex demo it’s often a good idea to define it in a separate JavaScript file and `import` it in Markdown. If the component file is in the same folder as the markdown, just do `import { myExample as exam } from './myExample';
+
+If you prefer to use JSX in your examples, use the [jsxInExample](/Configuration.md#jsxInExamples) option in `styleguide.config.js`.
+
+```jsx
+export default {
+  render() {
+    return <Button />
+  }
+}
+```

--- a/examples/.eslintrc
+++ b/examples/.eslintrc
@@ -7,6 +7,9 @@
 	},
 	"rules": {
 		"valid-jsdoc": 0,
-		"react/prefer-stateless-function": 0
+		"no-console": 0,
+		"react/prefer-stateless-function": 0,
+		"react/react-in-jsx-scope": 0,
+		"react/no-unknown-property": 0
 	}
 }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -32,7 +32,7 @@
     "@babel/preset-env": "^7.3.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "css-loader": "^0.28.7",
+    "css-loader": "^2.1.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/examples/customised/package.json
+++ b/examples/customised/package.json
@@ -31,7 +31,7 @@
     "@babel/preset-env": "^7.3.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "css-loader": "^0.28.7",
+    "css-loader": "^2.1.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/examples/dashed-component/package.json
+++ b/examples/dashed-component/package.json
@@ -34,7 +34,7 @@
 		"@babel/preset-env": "^7.3.1",
 		"babel-core": "^7.0.0-bridge.0",
 		"babel-loader": "^8.0.5",
-		"css-loader": "^0.28.7",
+		"css-loader": "^2.1.0",
 		"node-sass": "^4.11.0",
 		"sass-loader": "^6.0.6",
 		"style-loader": "^0.19.0",

--- a/examples/jsx-examples/Readme.md
+++ b/examples/jsx-examples/Readme.md
@@ -1,0 +1,12 @@
+# Vue Styleguidist jsx-examples example style guide
+
+How to start locally:
+
+```
+git clone https://github.com/vue-styleguidist/vue-styleguidist.git
+cd vue-styleguidist/examples/jsx-examples
+npm install
+npm run styleguide
+```
+
+Then open [http://localhost:6060](http://localhost:6060) in your browser.

--- a/examples/jsx-examples/package.json
+++ b/examples/jsx-examples/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "vue-styleguidist-example-jsx-examples",
+  "description": "Examples can contain jsx too",
+  "keywords": [
+		"jsx",
+		"buble",
+		"compiler",
+		"vue examples",
+		"functional"
+	],
+  "private": true,
+  "homepage": "https://github.com/vue-styleguidist/vue-styleguidist",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/styleguidist/vue-styleguidist.git"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=4"
+  },
+  "dependencies": {
+    "@znck/prop-types": "^0.6.1",
+    "dog-names": "^1.0.2",
+    "vue-types": "^1.5.0"
+  },
+  "scripts": {
+    "styleguide": "vue-styleguidist server",
+    "styleguide:build": "vue-styleguidist build"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.2.2",
+    "@babel/plugin-transform-runtime": "^7.2.0",
+    "@babel/preset-env": "^7.3.1",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-loader": "^8.0.5",
+    "babel-plugin-transform-vue-jsx": "4.0.1",
+    "css-loader": "^0.28.7",
+    "node-sass": "^4.11.0",
+    "sass-loader": "^6.0.6",
+    "style-loader": "^0.19.0",
+    "vue-loader": "^15.2.4",
+    "vue-styleguidist": "^3.10.1",
+    "webpack": "^4.10.0"
+  }
+}

--- a/examples/jsx-examples/package.json
+++ b/examples/jsx-examples/package.json
@@ -34,7 +34,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
     "babel-plugin-transform-vue-jsx": "4.0.1",
-    "css-loader": "^0.28.7",
+    "css-loader": "^2.1.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/examples/jsx-examples/src/components/Button/Button.jsx
+++ b/examples/jsx-examples/src/components/Button/Button.jsx
@@ -1,0 +1,70 @@
+import VueTypes from 'vue-types'
+import PropTypes from '@znck/prop-types'
+
+/**
+ * The only true button.
+ */
+export default {
+	name: 'Button',
+	props: {
+		/**
+		 * The color for the button.
+		 */
+		color: {
+			type: String,
+			default: '#333'
+		},
+		/**
+		 * The shape of my heart
+		 */
+		shape: PropTypes.shape({
+			color: PropTypes.string,
+			fontSize: PropTypes.number
+		}),
+		/**
+		 * The size of the button
+		 * `small, normal, large`
+		 */
+		size: VueTypes.string.def('normal'),
+		/**
+		 * Gets called when the user clicks on the button
+		 * @ignore
+		 */
+		onClick: {
+			type: Function,
+			default: event => {
+				console.log('You have clicked me!', event.target)
+			}
+		}
+	},
+	computed: {
+		fontSize() {
+			let size
+			switch (this.size) {
+				case 'small':
+					size = '10px'
+					break
+				case 'normal':
+					size = '14px'
+					break
+				case 'large':
+					size = '18px'
+					break
+			}
+			return size
+		}
+	},
+	render() {
+		return (
+			<div class="Button">
+				<button
+					class="button"
+					on-click={this.onClick}
+					style={{ color: this.color, fontSize: this.fontSize }}
+				>
+					{this.$slots.default}
+				</button>
+			</div>
+		)
+	}
+}

--- a/examples/jsx-examples/src/components/Button/Readme.md
+++ b/examples/jsx-examples/src/components/Button/Readme.md
@@ -1,0 +1,65 @@
+If you wish to, you can use JSX in your examples. Make sure you set the "jsxInExamples" flag to true in your `styleguide.config.js`
+
+A first example with a jsx file
+
+```jsx
+import { all as dogNames } from 'dog-names'
+
+// You can also use 'exports default {}' style module exports.
+export default {
+  data() {
+    return { numClicks: 0, dogName: dogNames[0] }
+  },
+  render() {
+    return (
+      <div staticClass="wrapper">
+        <Button native-on-click={this.pushButton}>Push Me</Button>
+        <hr />
+        <p staticClass="text-name">Next Dog Name: {this.dogName}</p>
+      </div>
+    )
+  },
+  methods: {
+    pushButton() {
+      this.numClicks += 1
+      this.dogName = dogNames[this.numClicks]
+    }
+  }
+}
+```
+
+You can as well use Single File Components with JSX. This would allow you to style your JSX examples.
+
+```vue
+<script>
+import { all as dogNames } from 'dog-names'
+
+// You can also use 'exports default {}' style module exports.
+export default {
+  data() {
+    return { numClicks: 0, dogName: dogNames[0] }
+  },
+  render() {
+    return (
+      <div staticClass="wrapper">
+        <Button native-on-click={this.pushButton}>Push Me</Button>
+        <hr />
+        <p staticClass="text-name">Next Dog Name: {this.dogName}</p>
+      </div>
+    )
+  },
+  methods: {
+    pushButton() {
+      this.numClicks += 1
+      this.dogName = dogNames[this.numClicks]
+    }
+  }
+}
+</script>
+<style scoped>
+.wrapper {
+  background-color: #eeeeee;
+  padding: 11px;
+}
+</style>
+```

--- a/examples/jsx-examples/styleguide.config.js
+++ b/examples/jsx-examples/styleguide.config.js
@@ -1,0 +1,44 @@
+const vueLoader = require('vue-loader')
+
+module.exports = {
+	jsxInExamples: true,
+	simpleEditor: true,
+	title: 'Vue Styleguidist jsx example',
+	components: 'src/components/**/[A-Z]*.jsx',
+	defaultExample: false,
+	ribbon: {
+		text: 'Back to examples',
+		url: 'https://vue-styleguidist.github.io/Examples.html'
+	},
+	version: '1.1.1',
+	webpackConfig: {
+		module: {
+			rules: [
+				{
+					test: /\.vue$/,
+					loader: 'vue-loader'
+				},
+				{
+					test: /\.(jsx|js)$/,
+					exclude: /node_modules/,
+					use: {
+						loader: 'babel-loader',
+						options: {
+							presets: ['@babel/preset-env'],
+							plugins: ['transform-vue-jsx']
+						}
+					}
+				},
+				{
+					test: /\.css$/,
+					use: ['style-loader', 'css-loader']
+				}
+			]
+		},
+
+		plugins: [new vueLoader.VueLoaderPlugin()]
+	},
+	usageMode: 'expand',
+	exampleMode: 'expand',
+	styleguideDir: 'dist'
+}

--- a/examples/jsx/Readme.md
+++ b/examples/jsx/Readme.md
@@ -1,10 +1,10 @@
-# Vue Styleguidist basic example style guide
+# Vue Styleguidist jsx example style guide
 
 How to start locally:
 
 ```
 git clone https://github.com/vue-styleguidist/vue-styleguidist.git
-cd vue-styleguidist/examples/basic
+cd vue-styleguidist/examples/jsx
 npm install
 npm run styleguide
 ```

--- a/examples/jsx/package.json
+++ b/examples/jsx/package.json
@@ -27,7 +27,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
     "babel-plugin-transform-vue-jsx": "4.0.1",
-    "css-loader": "^0.28.7",
+    "css-loader": "^2.1.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/examples/jsx/src/components/Button/Button.jsx
+++ b/examples/jsx/src/components/Button/Button.jsx
@@ -6,19 +6,6 @@ import loggerMixin from '../../mixins/loggerMixin'
  * The only true button.
  */
 export default {
-	render(h) {
-		return (
-			<div class="Button">
-				<button
-					class="button"
-					on-click={this.onClick}
-					style={{ color: this.color, fontSize: this.fontSize }}
-				>
-					{this.$slots.default}
-				</button>
-			</div>
-		)
-	},
 	name: 'Button',
 	mixins: [loggerMixin],
 	props: {
@@ -68,5 +55,18 @@ export default {
 			}
 			return size
 		}
+	},
+	render() {
+		return (
+			<div class="Button">
+				<button
+					class="button"
+					on-click={this.onClick}
+					style={{ color: this.color, fontSize: this.fontSize }}
+				>
+					{this.$slots.default}
+				</button>
+			</div>
+		)
 	}
 }

--- a/examples/jsx/src/components/Button/Readme.md
+++ b/examples/jsx/src/components/Button/Readme.md
@@ -37,7 +37,7 @@ You can also use the Single File Component Format
 <script>
 const dogNames = require('dog-names').all
 
-// You can also use 'exports.default = {}' style module exports.
+// You can also use 'export default {}' style module exports.
 export default {
   data() {
     return { numClicks: 0, dogName: dogNames[0] }

--- a/examples/nuxtjs/package.json
+++ b/examples/nuxtjs/package.json
@@ -29,7 +29,7 @@
     "@nuxtjs/axios": "5.4.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "css-loader": "^0.28.7",
+    "css-loader": "^2.1.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/examples/router/package.json
+++ b/examples/router/package.json
@@ -34,7 +34,7 @@
 		"@babel/preset-env": "^7.3.1",
 		"babel-core": "^7.0.0-bridge.0",
 		"babel-loader": "^8.0.5",
-		"css-loader": "^0.28.7",
+		"css-loader": "^2.1.0",
 		"node-sass": "^4.11.0",
 		"sass-loader": "^6.0.6",
 		"style-loader": "^0.19.0",

--- a/examples/sections/package.json
+++ b/examples/sections/package.json
@@ -24,7 +24,7 @@
     "@babel/preset-env": "^7.3.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "css-loader": "^0.28.7",
+    "css-loader": "^2.1.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/examples/vuetify/package.json
+++ b/examples/vuetify/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-env": "^7.3.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "css-loader": "^0.28.7",
+    "css-loader": "^2.1.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/examples/vuex/package.json
+++ b/examples/vuex/package.json
@@ -21,7 +21,7 @@
     "@babel/preset-env": "^7.3.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "css-loader": "^0.28.7",
+    "css-loader": "^2.1.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/examples/with-laravel-token/package.json
+++ b/examples/with-laravel-token/package.json
@@ -32,7 +32,7 @@
 		"@babel/preset-env": "^7.3.1",
 		"babel-core": "^7.0.0-bridge.0",
 		"babel-loader": "^8.0.5",
-		"css-loader": "^0.28.7",
+		"css-loader": "^2.1.0",
 		"node-sass": "^4.11.0",
 		"sass-loader": "^6.0.6",
 		"style-loader": "^0.19.0",

--- a/examples/with-sass-loader/package.json
+++ b/examples/with-sass-loader/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-env": "^7.3.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.5",
-    "css-loader": "^0.28.7",
+    "css-loader": "^2.1.0",
     "node-sass": "^4.11.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",

--- a/packages/vue-inbrowser-compiler/README.md
+++ b/packages/vue-inbrowser-compiler/README.md
@@ -10,10 +10,147 @@ yarn add vue-inbrowser-compiler
 
 ## usage
 
-### isVueSFC
-
-### adaptCreateElement
+This library is meant to help write components for vue that can be edited through text.
 
 ### compile
+
+Compiles a string of pseudo javascript code written in es2015. It returns the body of a function as a string. Once you execute the function, it will return a VueJS component.
+
+```js
+import { compile } from 'vue-inbrowser-compiler'
+
+/**
+ * render a component
+ */
+function getComponent(code) {
+  const conpiledCode = compile(
+    code,
+    // pass in config options to buble to set up the output
+    {
+      target: { ie: 11 }
+    }
+  )
+  const func = new Function(code)
+  return func()
+}
+```
+
+The formats of the code here are the same as vue-live and vue-styleguidist
+
+#### pseudo jsx
+
+Most common use case is a simple vue template.
+
+```html
+<Button color="blue">Test This Buttton</Button>
+```
+
+will be transformed into
+
+```js
+return {
+  template: '<Button color="blue">Test This Buttton</Button>'
+}
+```
+
+A more advanced use case if you want to use variables
+
+```jsx
+// initialize variables here and use them below
+let show = true
+let today = new Date();
+
+// starting from the first line that starts with a <tag>,
+// the rest is considered a template
+<input type="checkbox" v-model="show">
+<date-picker
+  style="text-align:center;"
+  v-if="show"
+  :value="today"/>
+```
+
+will turn into
+
+```js
+let show = true
+let today = new Date();
+
+return {
+    data(){
+        return{
+            show: show,
+            today: today
+        }
+    }
+    template: `<input type="checkbox" v-model="show">
+<date-picker
+  style="text-align:center;"
+  v-if="show"
+  :value="today"/>`
+}
+```
+
+#### Vue apps
+
+A simple way to make it explicit
+
+```js
+new Vue({
+  template: `
+<div>
+  <input v-model="value" type="checkbox">
+  <h1 v-if="value">I am checked</h1>
+</div>`,
+  data() {
+    return {
+      value: false
+    }
+  }
+})
+```
+
+#### Single File Components
+
+```html
+<template>
+  <div class="hello">
+    <h1>Colored Text</h1>
+    <button>{{ msg }}</button>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      msg: "Push Me"
+    };
+  }
+};
+</script>
+
+<style>
+.hello {
+  text-align: center;
+  color: #900;
+}
+</style>
+```
+
+### isCodeVueSfc
+
+Detects if the code given corresponds to a VueJS [Single File Component](https://vuejs.org/v2/guide/single-file-components.html). If there is a `<template>` or a `<script>` tag, it will return true, otherwise return false.
+
+```js
+import { isCodeVueSfc } from 'vue-inbrowser-compiler'
+
+if (isCodeVueSfc(code)) {
+  doStuffForSFC(code)
+} else {
+  doStuffForJSFiles(code)
+}
+```
+
+### adaptCreateElement
 
 ### addScopedStyle

--- a/packages/vue-inbrowser-compiler/README.md
+++ b/packages/vue-inbrowser-compiler/README.md
@@ -16,6 +16,8 @@ This library is meant to help write components for vue that can be edited throug
 
 Compiles a string of pseudo javascript code written in es2015. It returns the body of a function as a string. Once you execute the function, it will return a VueJS component.
 
+**prototype**: `compile(code: string, config: BubleConfig): {script: string, style: string}`
+
 ```js
 import { compile } from 'vue-inbrowser-compiler'
 
@@ -30,7 +32,7 @@ function getComponent(code) {
       target: { ie: 11 }
     }
   )
-  const func = new Function(code)
+  const func = new Function(conpiledCode.script)
   return func()
 }
 ```
@@ -141,6 +143,8 @@ export default {
 
 Detects if the code given corresponds to a VueJS [Single File Component](https://vuejs.org/v2/guide/single-file-components.html). If there is a `<template>` or a `<script>` tag, it will return true, otherwise return false.
 
+**prototype**: `isCodeVueSfc(code: string):boolean`
+
 ```js
 import { isCodeVueSfc } from 'vue-inbrowser-compiler'
 
@@ -151,6 +155,32 @@ if (isCodeVueSfc(code)) {
 }
 ```
 
+### addScopedStyle
+
+Takes the css style passed in first argument, scopes it using the suffix and adds it to the current page.
+
+**prototype**: `addScopedStyle(css: string, suffix: string):void`
+
 ### adaptCreateElement
 
-### addScopedStyle
+In order to make JSX work with the compiler, you need to specify a pragma. Since tis pragma has a different form for VueJs than for ReactJs, we need to provide an adapter.
+
+```js
+import { compile, adaptCreateElement } from 'vue-inbrowser-compiler'
+
+/**
+ * render a JSX component
+ */
+function getComponent(code) {
+  const conpiledCode = compile(
+    code,
+    // in this config we set up the jsx pragma to a higher order function
+    {
+      jsx: '__pragma__(h)'
+    }
+  )
+  const func = new Function('__pragma__', conpiledCode.script)
+  // now pass the higher order function to the function call
+  return func(adaptCreateElement)
+}
+```

--- a/packages/vue-inbrowser-compiler/README.md
+++ b/packages/vue-inbrowser-compiler/README.md
@@ -8,6 +8,12 @@ Compile vue components code into vue components objects inside of your browser
 yarn add vue-inbrowser-compiler
 ```
 
-## use
+## usage
 
-To be written
+### isVueSFC
+
+### adaptCreateElement
+
+### compile
+
+### addScopedStyle

--- a/packages/vue-inbrowser-compiler/package.json
+++ b/packages/vue-inbrowser-compiler/package.json
@@ -17,7 +17,10 @@
   ],
   "dependencies": {
     "acorn": "^6.1.1",
+    "acorn-jsx": "^5.0.1",
+    "babel-plugin-transform-vue-jsx": "^3.7.0",
     "buble": "^0.19.7",
+    "camelcase": "^5.3.1",
     "vue-template-compiler": "^2.6.10",
     "walkes": "^0.2.1"
   },

--- a/packages/vue-inbrowser-compiler/src/__tests__/compileVueCodeForEvalFunction.ts
+++ b/packages/vue-inbrowser-compiler/src/__tests__/compileVueCodeForEvalFunction.ts
@@ -54,7 +54,7 @@ new Vue({
 		expect(dummySet.data()).toMatchObject({ param: 'BazFoo' })
 	})
 
-	it('compile code from SFCs', () => {
+	it('should compile code from SFCs without a template', () => {
 		const sut = compileVueCodeForEvalFunction(`
 <script>
 const bar = "foo"
@@ -63,5 +63,21 @@ export default {}
 		const dummySet = sut.script
 		expect(dummySet).toContain('var bar')
 		expect(dummySet).not.toContain('export default')
+	})
+
+	it('should compile JSX', () => {
+		const sut = compileVueCodeForEvalFunction(
+			`
+export default {
+	render(){
+		return (
+			<HelloWorld />
+		)
+	}
+}`,
+			{ jsx: 'pragma' }
+		)
+		const dummySet = sut.script
+		expect(dummySet).toContain('pragma( HelloWorld')
 	})
 })

--- a/packages/vue-inbrowser-compiler/src/__tests__/normalizeSfcComponent.ts
+++ b/packages/vue-inbrowser-compiler/src/__tests__/normalizeSfcComponent.ts
@@ -50,4 +50,25 @@ module.exports = {
 </script>`)
 		expect(evalFunction(sut)).toMatchObject({ template: '\n<div/>\n', param: 'Foo' })
 	})
+
+	it('should add const h = this.createElement at the beginning of a render function', () => {
+		const sut = normalizeSfcComponent(`
+<script>
+export default {
+render() {
+	return h(Button)
+},
+data(){
+	return {
+		test:1
+	}
+},
+computed:{
+	propsSides(){
+		return hello();
+	}
+}}
+</script>`)
+		expect(evalFunction(sut).render.toString()).toMatch(/const h = this\.\$createElement/)
+	})
 })

--- a/packages/vue-inbrowser-compiler/src/adaptCreateElement.ts
+++ b/packages/vue-inbrowser-compiler/src/adaptCreateElement.ts
@@ -1,6 +1,6 @@
 const camelCase = require('camelcase')
 
-export default function createElement(
+export default function adaptCreateElement(
 	h: (comp: object | string, attr: { [key: string]: any }, children: any[]) => any[] | any
 ) {
 	return (comp: object | string, attr: { [key: string]: any }, ...children: any[]): any[] | any => {

--- a/packages/vue-inbrowser-compiler/src/adaptCreateElement.ts
+++ b/packages/vue-inbrowser-compiler/src/adaptCreateElement.ts
@@ -1,9 +1,14 @@
 const camelCase = require('camelcase')
 
+/**
+ * Groups atributes passed to a React pragma to the VueJS fashion
+ * @param h the VueJS createElement function passed in render functions
+ * @returns pragma usable in buble rendered JSX for VueJS
+ */
 export default function adaptCreateElement(
 	h: (comp: object | string, attr: { [key: string]: any }, children: any[]) => any[] | any
-) {
-	return (comp: object | string, attr: { [key: string]: any }, ...children: any[]): any[] | any => {
+): (comp: object | string, attr: { [key: string]: any }, ...children: any[]) => any[] | any {
+	return (comp, attr, ...children) => {
 		return h(comp, groupAttr(attr), children)
 	}
 }

--- a/packages/vue-inbrowser-compiler/src/addScopedStyle.ts
+++ b/packages/vue-inbrowser-compiler/src/addScopedStyle.ts
@@ -1,8 +1,10 @@
 import scoper from './styleScoper'
 
 /**
- * Add a style block to the head to load the styles.
+ * Adds a style block to the head to load the styles.
  * uses the suffix to scope the styles
+ * @param {string} css css code to add the the head
+ * @param {string} suffix string to add to each selector as a scoped style to avoid conflicts
  */
 export default function addScopedStyle(css: string, suffix: string) {
 	const head = document.head || document.getElementsByTagName('head')[0]

--- a/packages/vue-inbrowser-compiler/src/compileVueCodeForEvalFunction.ts
+++ b/packages/vue-inbrowser-compiler/src/compileVueCodeForEvalFunction.ts
@@ -15,7 +15,7 @@ interface EvaluableComponent {
  * Reads the code in string and separates the javascript part and the html part
  * then sets the nameVarComponent variable with the value of the component parameters
  * @param {string} code
- * @param {object} config buble config tobe used when transforming
+ * @param {object} config buble config to be used when transforming
  * @return {script:String, template:String}
  *
  */

--- a/packages/vue-inbrowser-compiler/src/compileVueCodeForEvalFunction.ts
+++ b/packages/vue-inbrowser-compiler/src/compileVueCodeForEvalFunction.ts
@@ -14,9 +14,8 @@ interface EvaluableComponent {
 /**
  * Reads the code in string and separates the javascript part and the html part
  * then sets the nameVarComponent variable with the value of the component parameters
- * @param {string} code
- * @param {object} config buble config to be used when transforming
- * @return {script:String, template:String}
+ * @param code
+ * @param config buble config to be used when transforming
  *
  */
 export default function compileVueCodeForEvalFunction(

--- a/packages/vue-inbrowser-compiler/src/createElement.ts
+++ b/packages/vue-inbrowser-compiler/src/createElement.ts
@@ -1,0 +1,47 @@
+const camelCase = require('camelcase')
+
+export default function createElement(
+	h: (comp: object | string, attr: { [key: string]: any }, children: any[]) => any[] | any
+) {
+	return (comp: object | string, attr: { [key: string]: any }, ...children: any[]): any[] | any => {
+		return h(comp, groupAttr(attr), children)
+	}
+}
+
+const rootAttributes = [
+	'staticClass',
+	'class',
+	'style',
+	'key',
+	'ref',
+	'refInFor',
+	'slot',
+	'scopedSlots',
+	'model'
+]
+
+const onRE = /(on|nativeOn|domProps)([A-Z][a-zA-Z]+)/
+
+const groupAttr = (attrs: { [key: string]: any }): { [key: string]: any } => {
+	if (!attrs) return attrs
+	const attributes: { [key: string]: any } = {}
+	Object.keys(attrs).forEach(name => {
+		const value = attrs[name]
+		const ccName = camelCase(name)
+		if (rootAttributes.includes(ccName)) {
+			attributes[ccName] = value
+		} else if (onRE.test(ccName)) {
+			const foundName = onRE.exec(ccName)
+			if (foundName) {
+				const rawEventName = foundName[2]
+				const eventName = camelCase(rawEventName)
+				const prefix = foundName[1]
+				if (!attributes[prefix]) {
+					attributes[prefix] = {}
+				}
+				attributes[prefix][eventName] = value
+			}
+		}
+	})
+	return attributes
+}

--- a/packages/vue-inbrowser-compiler/src/getAst.ts
+++ b/packages/vue-inbrowser-compiler/src/getAst.ts
@@ -1,7 +1,11 @@
-import { parse, Node } from 'acorn'
+import { Parser, Node } from 'acorn'
+
+const jsx = require('acorn-jsx')
+
+const extendedParser = Parser.extend(jsx())
 
 export default function getAst(code: string): Node {
-	return parse(code, {
+	return extendedParser.parse(code, {
 		ecmaVersion: 2019,
 		sourceType: 'module'
 	})

--- a/packages/vue-inbrowser-compiler/src/index.ts
+++ b/packages/vue-inbrowser-compiler/src/index.ts
@@ -1,4 +1,4 @@
 export { default as addScopedStyle } from './addScopedStyle'
 export { default as compile } from './compileVueCodeForEvalFunction'
-export { default as pragmaJSX } from './createElement'
+export { default as adaptCreateElement } from './adaptCreateElement'
 export { default as isCodeVueSfc } from './isCodeVueSfc'

--- a/packages/vue-inbrowser-compiler/src/index.ts
+++ b/packages/vue-inbrowser-compiler/src/index.ts
@@ -1,3 +1,4 @@
 export { default as addScopedStyle } from './addScopedStyle'
 export { default as compile } from './compileVueCodeForEvalFunction'
+export { default as pragmaJSX } from './createElement'
 export { default as isCodeVueSfc } from './isCodeVueSfc'

--- a/packages/vue-inbrowser-compiler/src/isCodeVueSfc.ts
+++ b/packages/vue-inbrowser-compiler/src/isCodeVueSfc.ts
@@ -1,6 +1,11 @@
 import { parseComponent } from 'vue-template-compiler'
 
-export default function isCodeVueSfc(code: string) {
+/**
+ * Determines if the given code is a VueSfc file
+ * It does not throw if the code is invalid, just returns `false`
+ * @param code JavaScript or vue code to analyze
+ */
+export default function isCodeVueSfc(code: string): boolean {
 	const parts = parseComponent(code)
 	return !!parts.script || !!parts.template
 }

--- a/packages/vue-styleguidist/loaders/examples-loader.js
+++ b/packages/vue-styleguidist/loaders/examples-loader.js
@@ -19,13 +19,14 @@ const cleanComponentName = require('./utils/cleanComponentName')
 // Hack the react scaffolding to be able to load client
 const absolutize = filepath =>
 	path.resolve(
-		path.dirname(require.resolve('react-styleguidist')),
+		path.dirname(require.resolve('vue-styleguidist')),
 		'../loaders/utils/client',
 		filepath
 	)
 
 const REQUIRE_IN_RUNTIME_PATH = absolutize('requireInRuntime')
 const EVAL_IN_CONTEXT_PATH = absolutize('evalInContext')
+const PRAGMA_JSX_PATH = require.resolve('vue-inbrowser-compiler')
 
 function isVueFile(filepath) {
 	return /.vue$/.test(filepath)
@@ -38,7 +39,8 @@ module.exports = function examplesLoader(source) {
 		source = getComponentVueDoc(source, filePath)
 	}
 	const config = this._styleguidist
-	const { displayName, shouldShowDefaultExample, customLangs } = loaderUtils.getOptions(this) || {}
+	const { file, displayName, shouldShowDefaultExample, customLangs } =
+		loaderUtils.getOptions(this) || {}
 
 	const cleanDisplayName = displayName ? cleanComponentName(displayName) : undefined
 	// Replace placeholders (__COMPONENT__) with the passed-in component name
@@ -54,6 +56,11 @@ module.exports = function examplesLoader(source) {
 	const examples = chunkify(source, updateExample, customLangs)
 
 	const getScript = code => {
+		// if in JSX mode just parse code as is
+		if (config.jsxInExamples) {
+			return code
+		}
+
 		// script is at the beginning of a line after a return
 		// In case we are loading a vue component as an example, extract script tag
 		if (isCodeVueSfc(code)) {
@@ -64,9 +71,7 @@ module.exports = function examplesLoader(source) {
 		return code.split(/\n[\t ]*</)[0]
 	}
 
-	const getExampleLiveImports = source => {
-		return getImports(getScript(source))
-	}
+	const getExampleLiveImports = source => getImports(getScript(source))
 
 	// Find all import statements and require() calls in examples to make them
 	// available in webpack context at runtime.
@@ -77,8 +82,21 @@ module.exports = function examplesLoader(source) {
 		return requires.concat(getExampleLiveImports(example.content))
 	}, [])
 
+	// Auto imported modules.
+	// We don't need to do anything here to support explicit imports: they will
+	// work because both imports (generated below and by rewrite-imports) will
+	// be eventually transpiled to `var x = require('x')`, so we'll just have two
+	// of them in the same scope, which is fine in non-strict mode
+	const fullContext = {
+		// Modules, provied by the user
+		...config.context,
+		// Append the current component module to make it accessible in examples
+		// without an explicit import
+		...(displayName && config.jsxInExamples ? { [displayName]: file } : {})
+	}
+
 	// All required or imported modules
-	const allModules = [...requiresFromExamples, ...values(config.context)]
+	const allModules = [...requiresFromExamples, ...values(fullContext)]
 
 	// “Prerequire” modules required in Markdown examples and context so they
 	// end up in a bundle and be available at runtime
@@ -88,18 +106,26 @@ module.exports = function examplesLoader(source) {
 	}, {})
 
 	// Require context modules so they are available in an example
+	let marker = -1
 	const requireContextCode = b.program(
 		flatten(
-			map(config.context, (requireRequest, name) => [
+			map(fullContext, (requireRequest, name) => [
 				// const name$0 = require(path);
 				b.variableDeclaration('const', [
-					b.variableDeclarator(b.identifier(`${name}$0`), requireIt(requireRequest).toAST())
+					b.variableDeclarator(
+						b.identifier(`${name}$${++marker}`),
+						requireIt(requireRequest).toAST()
+					)
 				]),
 				// const name = name$0.default || name$0;
 				b.variableDeclaration('const', [
 					b.variableDeclarator(
 						b.identifier(name),
-						b.logicalExpression('||', b.identifier(`${name}$0.default`), b.identifier(`${name}$0`))
+						b.logicalExpression(
+							'||',
+							b.identifier(`${name}$${marker}.default`),
+							b.identifier(`${name}$${marker}`)
+						)
 					)
 				])
 			])
@@ -119,12 +145,14 @@ if (module.hot) {
 	module.hot.accept([])
 }
 var requireMap = ${generate(toAst(allModulesCode))};
-var requireInRuntimeBase = require(${JSON.stringify(REQUIRE_IN_RUNTIME_PATH)}).default;
+var requireInRuntimeBase = require(${JSON.stringify(REQUIRE_IN_RUNTIME_PATH)});
 var requireInRuntime = requireInRuntimeBase.bind(null, requireMap);
-var evalInContextBase = require(${JSON.stringify(EVAL_IN_CONTEXT_PATH)}).default;
+var __pragma__ = require(${JSON.stringify(PRAGMA_JSX_PATH)}).pragmaJSX;
+
+var evalInContextBase = require(${JSON.stringify(EVAL_IN_CONTEXT_PATH)});
 var evalInContext = evalInContextBase.bind(null, ${JSON.stringify(
 		generate(requireContextCode)
-	)}, requireInRuntime);
+	)}, requireInRuntime, __pragma__);
 module.exports = ${generate(toAst(examplesWithEval))}
 	`
 }

--- a/packages/vue-styleguidist/loaders/examples-loader.js
+++ b/packages/vue-styleguidist/loaders/examples-loader.js
@@ -26,7 +26,7 @@ const absolutize = filepath =>
 
 const REQUIRE_IN_RUNTIME_PATH = absolutize('requireInRuntime')
 const EVAL_IN_CONTEXT_PATH = absolutize('evalInContext')
-const PRAGMA_JSX_PATH = require.resolve('vue-inbrowser-compiler')
+const PRAGMA_JSX_PATH = require.resolve('vue-inbrowser-compiler/lib/adaptCreateElement')
 
 function isVueFile(filepath) {
 	return /.vue$/.test(filepath)
@@ -147,7 +147,7 @@ if (module.hot) {
 var requireMap = ${generate(toAst(allModulesCode))};
 var requireInRuntimeBase = require(${JSON.stringify(REQUIRE_IN_RUNTIME_PATH)});
 var requireInRuntime = requireInRuntimeBase.bind(null, requireMap);
-var __pragma__ = require(${JSON.stringify(PRAGMA_JSX_PATH)}).pragmaJSX;
+var __pragma__ = require(${JSON.stringify(PRAGMA_JSX_PATH)}).default;
 
 var evalInContextBase = require(${JSON.stringify(EVAL_IN_CONTEXT_PATH)});
 var evalInContext = evalInContextBase.bind(null, ${JSON.stringify(

--- a/packages/vue-styleguidist/loaders/styleguide-loader.js
+++ b/packages/vue-styleguidist/loaders/styleguide-loader.js
@@ -26,7 +26,8 @@ const CLIENT_CONFIG_OPTIONS = [
 	'editorConfig',
 	'ribbon',
 	'pagePerSection',
-	'mountPointId'
+	'mountPointId',
+	'jsxInExamples'
 ]
 
 module.exports = function() {}

--- a/packages/vue-styleguidist/loaders/utils/client/evalInContext.js
+++ b/packages/vue-styleguidist/loaders/utils/client/evalInContext.js
@@ -12,12 +12,13 @@
  *
  * @param {string} header
  * @param {Function} require
+ * @param {Function} __pragma__
  * @param {string} code
  * @return {Function}
  */
-module.exports = function evalInContext(header, require, code) {
-	var func = new Function('require', 'state', 'setState', header + code) // eslint-disable-line no-new-func
+module.exports = function evalInContext(header, require, __pragma__, code) {
+	var func = new Function('require', '__pragma__', header + code) // eslint-disable-line no-new-func
 
 	// Bind the `require` function, other context arguments will be passed from the frontend
-	return func.bind(null, require)
+	return func.bind(null, require, __pragma__)
 }

--- a/packages/vue-styleguidist/scripts/schemas/config.js
+++ b/packages/vue-styleguidist/scripts/schemas/config.js
@@ -68,6 +68,28 @@ module.exports = {
 		default: false,
 		process: val => (val === true ? path.resolve(__dirname, '../templates/DefaultExample.md') : val)
 	},
+	editorConfig: {
+		type: 'object',
+		process: (value, config) => {
+			const defaults = {
+				theme: 'base16-light',
+				mode: 'jsx',
+				lineWrapping: true,
+				smartIndent: false,
+				matchBrackets: true,
+				viewportMargin: Infinity,
+				lineNumbers: false
+			}
+			return Object.assign(
+				{},
+				defaults,
+				config.highlightTheme && {
+					theme: config.highlightTheme
+				},
+				value
+			)
+		}
+	},
 	exampleMode: {
 		message: 'Example Mode',
 		description: 'Defines the initial state of the props and methods tab',
@@ -120,27 +142,11 @@ module.exports = {
 		type: 'boolean',
 		default: true
 	},
-	editorConfig: {
-		type: 'object',
-		process: (value, config) => {
-			const defaults = {
-				theme: 'base16-light',
-				mode: 'jsx',
-				lineWrapping: true,
-				smartIndent: false,
-				matchBrackets: true,
-				viewportMargin: Infinity,
-				lineNumbers: false
-			}
-			return Object.assign(
-				{},
-				defaults,
-				config.highlightTheme && {
-					theme: config.highlightTheme
-				},
-				value
-			)
-		}
+	jsxInExamples: {
+		message: 'JSX in Markdown Examples',
+		description: 'Do exmaples contain JSX syntax?',
+		type: 'boolean',
+		default: false
 	},
 	locallyRegisterComponents: {
 		message: 'Locally register components',

--- a/packages/vue-styleguidist/src/rsg-components/Preview/Preview.js
+++ b/packages/vue-styleguidist/src/rsg-components/Preview/Preview.js
@@ -79,7 +79,10 @@ class Preview extends Component {
 		let previewComponent = {}
 
 		try {
-			const example = compile(code, this.context.config.compilerConfig)
+			const example = compile(code, {
+				...this.context.config.compilerConfig,
+				...(this.context.config.jsxInExamples ? { jsx: '__pragma__(h)' } : {})
+			})
 			style = example.style
 			if (example.script) {
 				// compile and execute the script

--- a/yarn.lock
+++ b/yarn.lock
@@ -5675,7 +5675,7 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-camelcase@^5.0.0, camelcase@^5.2.0:
+camelcase@^5.0.0, camelcase@^5.2.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==


### PR DESCRIPTION
- [x] Allow acorn to parse JSX in examples
- [x] Add a flag to the config to enable it as opt-in
- [x] Make the compiler compile JSX
- [x] Import current component automatically (only in JSX mode)
- [x] Make JSX pragma compatible with `native-on-click` instead of `nativeOnClick`
- [x] Document the inbrowser compiler use case
- [ ] Allow pseudo-JSX and JSX examples together
- [ ] Extract the vue-pragma in a new package
