### PR TITLE
perf: only precompile example for prod

### DIFF
--- a/packages/vue-styleguidist/loaders/examples-loader.js
+++ b/packages/vue-styleguidist/loaders/examples-loader.js
@@ -169,14 +169,20 @@ module.exports = function examplesLoader(source) {
 					)
 			}
 			if (config.codeSplit) {
-				const compiledExample = compile(example.content, {
-					...config.compilerConfig,
-					...(config.jsxInExamples ? { jsx: '__pragma__(h)', objectAssign: 'concatenate' } : {})
-				})
-				example.compiled = {
-					script: compiledExample.script,
-					template: compiledExample.template,
-					style: compiledExample.style
+				if (process.env.NODE_ENV !== 'production') {
+					// if we are not in prod, we want to avoid running examples through
+					// buble all at the same time. We then tell it to calsculate on the fly
+					example.compiled = false
+				} else {
+					const compiledExample = compile(example.content, {
+						...config.compilerConfig,
+						...(config.jsxInExamples ? { jsx: '__pragma__(h)', objectAssign: 'concatenate' } : {})
+					})
+					example.compiled = {
+						script: compiledExample.script,
+						template: compiledExample.template,
+						style: compiledExample.style
+					}
 				}
 			}
 		}

--- a/packages/vue-styleguidist/src/rsg-components/PlaygroundAsync/PlaygroundAsync.js
+++ b/packages/vue-styleguidist/src/rsg-components/PlaygroundAsync/PlaygroundAsync.js
@@ -8,11 +8,14 @@ class PlaygroundAsync extends Component {
 		...Playground.propTypes,
 		code: PropTypes.shape({
 			raw: PropTypes.string.isRequired,
-			compiled: PropTypes.shape({
-				script: PropTypes.string,
-				template: PropTypes.string,
-				style: PropTypes.string
-			}).isRequired
+			compiled: PropTypes.oneOfType([
+				PropTypes.shape({
+					script: PropTypes.string,
+					template: PropTypes.string,
+					style: PropTypes.string
+				}),
+				PropTypes.bool
+			])
 		}).isRequired
 	}
 

--- a/packages/vue-styleguidist/src/rsg-components/Preview/PreviewAsync.js
+++ b/packages/vue-styleguidist/src/rsg-components/Preview/PreviewAsync.js
@@ -9,7 +9,17 @@ import cleanComponentName from '../../utils/cleanComponentName'
 
 class Preview extends Component {
 	static propTypes = {
-		code: PropTypes.object.isRequired,
+		code: PropTypes.shape({
+			raw: PropTypes.string.isRequired,
+			compiled: PropTypes.oneOfType([
+				PropTypes.shape({
+					script: PropTypes.string,
+					template: PropTypes.string,
+					style: PropTypes.string
+				}),
+				PropTypes.bool
+			])
+		}).isRequired,
 		evalInContext: PropTypes.func.isRequired,
 		vuex: PropTypes.object,
 		component: PropTypes.object,
@@ -32,7 +42,11 @@ class Preview extends Component {
 			console.clear()
 		}
 
-		this.setCompiledPreview(this.props.code.compiled)
+		if (this.props.code.compiled) {
+			this.setCompiledPreview(this.props.code.compiled)
+		} else {
+			this.executeCode(this.props.code.raw)
+		}
 	}
 
 	shouldComponentUpdate(nextProps, nextState) {

--- a/packages/vue-styleguidist/src/utils/processComponents.js
+++ b/packages/vue-styleguidist/src/utils/processComponents.js
@@ -23,7 +23,7 @@ export default function processComponents(components) {
 
 		newComponent.props.examples.forEach(ex => {
 			if (ex.type === 'code') {
-				if (ex.compiled && !ex.content.compiled) {
+				if (ex.compiled !== undefined && !ex.content.raw) {
 					ex.content = { raw: ex.content }
 					ex.content.compiled = ex.compiled
 				}


### PR DESCRIPTION
cc @JessicaSachs 
This is to avoid precompiling example with greedy buble while running the dev server.