### PR TITLE
vue-docgen-cli add new feature (whether to create md files)

### DIFF
--- a/packages/vue-docgen-cli/src/multiMd.ts
+++ b/packages/vue-docgen-cli/src/multiMd.ts
@@ -50,8 +50,9 @@ export async function compile(
 	filePath: string
 ) {
 	const componentFile = docMap[filePath] || filePath
-	writeDownMdFile(
-		await compileMarkdown(config, componentFile),
-		config.getDestFile(componentFile, config)
-	)
+	const file = config.getDestFile(componentFile, config)
+	// if getDestFile is null,will not be create files
+	if (file) {
+		writeDownMdFile(await compileMarkdown(config, componentFile), file)
+	}
 }


### PR DESCRIPTION
Thank you very much for having such an excellent open source project.
when we use `vue-docgen-cli` to get markdown files,we can config `destFile`,such as
```js
//docgen.config.js
module.exports = {
    getDestFile: (file: string, config: DocgenCLIConfig) => path.join(config.outDir, file).replace(/\.vue$/ ".doc.md") // specify the name of the output md file
}
```
Sometimes we may have to do a lot of judgment work in the `getDestFile` custom function to determine whether we need to generate a markdown document.

such as in my config, i add a depth property,and in `getDestFile` to judge whether create md file!