### PR TITLE
Fix: Nuxt example used wrong styleguide config path in package json

### DIFF
--- a/examples/nuxtjs/package.json
+++ b/examples/nuxtjs/package.json
@@ -14,8 +14,8 @@
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
-    "styleguide": "vue-styleguidist server --config styleguide/styleguide.config.js",
-    "styleguide:build": "vue-styleguidist build --config styleguide/styleguide.config.js"
+    "styleguide": "vue-styleguidist server --config styleguide.config.js",
+    "styleguide:build": "vue-styleguidist build --config styleguide.config.js"
   },
   "dependencies": {
     "nuxt": "^2.3.4",


### PR DESCRIPTION
In the `package.json` was a different path to the `styleguide.config.js`, the example didn't work.