### PR TITLE
Fix handlers

### DIFF
--- a/packages/vue-docgen-api/src/main.ts
+++ b/packages/vue-docgen-api/src/main.ts
@@ -58,7 +58,7 @@ export async function parseSource(
 }
 
 function isOptionsObject(opts: any): opts is DocGenOptions {
-	return !!opts && (!!opts.alias || opts.jsx !== undefined)
+	return !!opts && (!!opts.alias || opts.jsx !== undefined || !!opts.addScriptHandlers || !!opts.addTemplateHandlers)
 }
 
 async function parsePrimitive(

--- a/packages/vue-docgen-api/tests/api/mock.vue
+++ b/packages/vue-docgen-api/tests/api/mock.vue
@@ -1,0 +1,19 @@
+<template>
+	<h1>hello</h1>
+</template>
+
+<script>
+export default {
+	name: 'mock',
+	props: {
+		reduce: {
+			type: Function,
+			/**
+			 * @param {Object|String} option
+			 * @return {Object|String}
+			 */
+			default: option => option,
+		}
+	}
+}
+</script>

--- a/packages/vue-docgen-api/tests/api/scriptHandlers.test.ts
+++ b/packages/vue-docgen-api/tests/api/scriptHandlers.test.ts
@@ -1,9 +1,9 @@
 import * as path from 'path'
-import { parse, ParseOptions, TemplateParserOptions } from '../../src/main'
-import Documentation from '../../src/Documentation'
 import { NodePath } from 'ast-types'
 import * as bt from '@babel/types'
 import { ASTElement } from 'vue-template-compiler'
+import { parse, ParseOptions, TemplateParserOptions } from '../../src/main'
+import Documentation from '../../src/Documentation'
 
 describe('extending handlers', () => {
 

--- a/packages/vue-docgen-api/tests/api/scriptHandlers.test.ts
+++ b/packages/vue-docgen-api/tests/api/scriptHandlers.test.ts
@@ -1,0 +1,47 @@
+import * as path from 'path'
+import { parse, ParseOptions, TemplateParserOptions } from '../../src/main'
+import Documentation from '../../src/Documentation'
+import { NodePath } from 'ast-types'
+import * as bt from '@babel/types'
+import { ASTElement } from 'vue-template-compiler'
+
+describe('extending handlers', () => {
+
+	it('should execute a custom script handler', async () => {
+		let hasRun = false
+
+		await parse(path.resolve(__dirname, 'mock.vue'), {
+			addScriptHandlers: [
+				async function handler(
+					doc: Documentation,
+					componentDefinition: NodePath,
+					ast: bt.File,
+					opt: ParseOptions
+				) {
+					hasRun = true
+				}
+			]
+		})
+
+		expect(hasRun).toBe(true)
+	})
+
+	it('should execute a custom template handler', async () => {
+		let hasRun = false
+
+		await parse(path.resolve(__dirname, 'mock.vue'), {
+			addTemplateHandlers: [
+				async function handler(
+					documentation: Documentation,
+					templateAst: ASTElement,
+					options: TemplateParserOptions
+				) {
+					hasRun = true
+				}
+			]
+		});
+
+		expect(hasRun).toBe(true)
+	})
+})
+


### PR DESCRIPTION
Functions in the `DocGenOptions.addTemplateHandlers`  and `DocGenOptions.addScriptHandlers` were not being run because `isOptionsObject` was always returning false when passed an object unless it contained `opts.alias` or `opts.jsx`.

I think `nameFilter` and `modules` probably need to be added to the checks as well.