### PR TITLE
fix(docgen): avoid incorrect of  getting nested "{" param type

### DIFF
--- a/packages/vue-docgen-api/src/utils/getDoclets.ts
+++ b/packages/vue-docgen-api/src/utils/getDoclets.ts
@@ -1,11 +1,11 @@
 import { BlockTag, DocBlockTags, Param, ParamType } from '../Documentation'
+import matchRecursiveRegExp from './matchRecursiveRegexp'
 
 const DOCLET_PATTERN = /^(?:\s+)?@(\w+)(?:$|\s((?:[^](?!^(?:\s+)?@\w))*))/gim
 
 function getParamInfo(content: string, hasName: boolean) {
 	content = content || ''
-	const typeSliceArray = /^\{([^}]+)\}/.exec(content)
-	const typeSlice = typeSliceArray && typeSliceArray.length ? typeSliceArray[1] : '*'
+	const typeSlice = matchRecursiveRegExp(content, '{', '}')[0]
 	const param: Param = { type: getTypeObjectFromTypeString(typeSlice) }
 
 	content = content.replace(`{${typeSlice}}`, '')

--- a/packages/vue-docgen-api/src/utils/matchRecursiveRegexp.ts
+++ b/packages/vue-docgen-api/src/utils/matchRecursiveRegexp.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-cond-assign */
+/**
+ * matching nested constructs
+ * thanks Steve Levithan
+ * @see http://blog.stevenlevithan.com/archives/javascript-match-recursive-regexp
+ * @param str
+ * @param left
+ * @param right
+ * @param flags
+ */
+export function matchRecursiveRegExp(str: string, left: string, right: string, flags: string = '') {
+	let f = flags
+	const g = f.indexOf('g') > -1
+	f = f.replace('g', '')
+	const x = new RegExp(`${left}|${right}`, `g${f}`)
+	const l = new RegExp(left, f.replace(/g/g, ''))
+	const a = []
+	let s: number = -1
+	let t
+	let m
+
+	do {
+		t = 0
+		while ((m = x.exec(str))) {
+			if (l.test(m[0])) {
+				if (!t++) s = x.lastIndex
+			} else if (t) {
+				if (!--t) {
+					a.push(str.slice(s, m.index))
+					if (!g) return a
+				}
+			}
+		}
+	} while (t && (x.lastIndex = s))
+
+	return a
+}
+export default matchRecursiveRegExp


### PR DESCRIPTION
The current version of the solution for identifying parameter types for strings containing "}" is incorrect
For example
```javascript
@param {{name: string}}
```
This pull request is trying to fix this bug 