### PR TITLE
fix(docgen): avoid incorrect of getting nested '}' param type

### DIFF
--- a/packages/vue-docgen-api/README.md
+++ b/packages/vue-docgen-api/README.md
@@ -18,40 +18,46 @@ The tool can be used programmatically to extract component information and custo
 
 ```js
 var vueDocs = require('vue-docgen-api')
-var componentInfo = vueDocs.parse(filePath)
+var componentInfo
+vueDocs.parse(filePath).then(ci => {
+  componentInfo = ci
+})
 ```
 
 or with typescript
 
 ```ts
 import { parse } from 'vue-docgen-api'
-var componentInfoSimple = parse(filePath)
-var componentInfoConfigured = parse(filePath, {
-  alias: { '@assets': path.resolve(__dirname, 'src/assets') },
-  resolve: [path.resolve(__dirname, 'src')],
-  addScriptHandler: [
-    function(
-      documentation: Documentation,
-      componentDefinition: NodePath,
-      astPath: bt.File,
-      opt: ParseOptions
-    ) {
-      // handle custom code in script
-    }
-  ],
-  addTemplateHandler: [
-    function(
-      documentation: Documentation,
-      templateAst: ASTElement,
-      options: TemplateParserOptions
-    ) {
-      // handle custom directives here
-    }
-  ]
-})
+
+async function parseMyComponent(filePath: string) {
+  var componentInfoSimple = await parse(filePath)
+  var componentInfoConfigured = await parse(filePath, {
+    alias: { '@assets': path.resolve(__dirname, 'src/assets') },
+    resolve: [path.resolve(__dirname, 'src')],
+    addScriptHandler: [
+      function(
+        documentation: Documentation,
+        componentDefinition: NodePath,
+        astPath: bt.File,
+        opt: ParseOptions
+      ) {
+        // handle custom code in script
+      }
+    ],
+    addTemplateHandler: [
+      function(
+        documentation: Documentation,
+        templateAst: ASTElement,
+        options: TemplateParserOptions
+      ) {
+        // handle custom directives here
+      }
+    ]
+  })
+}
 ```
 
-### parse(filePath:string, options?: DocGenOptions)
+### async parse(filePath:string, options?: DocGenOptions)
 
 | Parameter | Type   | Description   |
 | --------- | ------ | ------------- |
@@ -61,7 +67,76 @@ var componentInfoConfigured = parse(filePath, {
 
 You can use JSDoc tags when documenting components, props and methods.
 
-## Example
+## Props
+
+```js
+export default {
+  props: {
+    /**
+     * Color of the button.
+     */
+    color: {
+      type: String,
+      default: '#FCC'
+    },
+    /**
+     * initial value to be passed but undocumented
+     * @ignore
+     */
+    initialvalue: {
+      type: Number,
+      default: 0
+    },
+    /**
+     * The size of the button allows only some values
+     * @values small, medium, large
+     */
+    size: {
+      default: 'normal'
+    }
+  }
+}
+```
+
+## Events
+
+```js
+export default {
+  methods: {
+    emitSuccess() {
+      /**
+       * Success event.
+       *
+       * @event success
+       * @property {string} content content of the first prop passed to the event
+       * @property {object} example the demo example
+       */
+      this.$emit('success', content, {
+        demo: 'example'
+      })
+    }
+  }
+}
+```
+
+## Slots
+
+```html
+<template>
+  <div>
+    <!-- @slot Use this slot header -->
+    <slot name="header"></slot>
+
+    <!--
+      @slot Modal footer
+      @binding item an item passed to the footer
+		-->
+    <slot name="footer" :item="item" />
+  </div>
+</template>
+```
+
+## Full Example
 
 For the following component
 
@@ -75,8 +150,11 @@ For the following component
       <!-- -->
     </table>
 
-    <!-- @slot Use this slot footer -->
-    <slot name="footer"></slot>
+    <!--
+      @slot Modal footer
+      @binding item an item passed to the footer
+		-->
+    <slot name="footer" :item="item" />
   </div>
 </template>
 
@@ -396,34 +474,6 @@ we are getting this output:
     }
   }
 }
-```
-
-## Events
-
-```js
-/**
- * Success event.
- *
- * @event success
- * @property {object} example the demo example
- */
-this.$emit('success', {
-  demo: 'example'
-})
-```
-
-## Slots
-
-```html
-<template>
-  <div>
-    <!-- @slot Use this slot header -->
-    <slot name="header"></slot>
-
-    <!-- @slot Use this slot footer -->
-    <slot name="footer"></slot>
-  </div>
-</template>
 ```
 
 ## Change log

--- a/packages/vue-docgen-api/src/utils/__tests__/getDoclets.ts
+++ b/packages/vue-docgen-api/src/utils/__tests__/getDoclets.ts
@@ -46,6 +46,13 @@ describe('getDoclets', () => {
 		])
 	})
 
+	it('should extract param type with braces', () => {
+		const src = `@param {{name: string, id: number}} user`
+		expect(getDocLets(src).tags).toEqual([
+			{ name: 'user', title: 'param', type: { name: '{name: string, id: number}' } }
+		])
+	})
+
 	it('should extract description', () => {
 		const src = ['awesome method', ' ', '@version 1.2.3'].join('\n')
 		expect(getDocLets(src).description).toEqual('awesome method')

--- a/packages/vue-docgen-api/src/utils/getDoclets.ts
+++ b/packages/vue-docgen-api/src/utils/getDoclets.ts
@@ -1,11 +1,11 @@
 import { BlockTag, DocBlockTags, Param, ParamType } from '../Documentation'
+import matchRecursiveRegExp from './matchRecursiveRegexp'
 
 const DOCLET_PATTERN = /^(?:\s+)?@(\w+)(?:$|\s((?:[^](?!^(?:\s+)?@\w))*))/gim
 
 function getParamInfo(content: string, hasName: boolean) {
 	content = content || ''
-	const typeSliceArray = /^\{([^}]+)\}/.exec(content)
-	const typeSlice = typeSliceArray && typeSliceArray.length ? typeSliceArray[1] : '*'
+	const typeSlice = matchRecursiveRegExp(content, '{', '}')[0] || '*'
 	const param: Param = { type: getTypeObjectFromTypeString(typeSlice) }
 
 	content = content.replace(`{${typeSlice}}`, '')

--- a/packages/vue-docgen-api/src/utils/matchRecursiveRegexp.ts
+++ b/packages/vue-docgen-api/src/utils/matchRecursiveRegexp.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-cond-assign */
+/**
+ * matching nested constructs
+ * thanks Steve Levithan
+ * @see http://blog.stevenlevithan.com/archives/javascript-match-recursive-regexp
+ * @param str
+ * @param left
+ * @param right
+ * @param flags
+ */
+export function matchRecursiveRegExp(str: string, left: string, right: string, flags: string = '') {
+	let f = flags
+	const g = f.indexOf('g') > -1
+	f = f.replace('g', '')
+	const x = new RegExp(`${left}|${right}`, `g${f}`)
+	const l = new RegExp(left, f.replace(/g/g, ''))
+	const a = []
+	let s: number = -1
+	let t
+	let m
+
+	do {
+		t = 0
+		while ((m = x.exec(str))) {
+			if (l.test(m[0])) {
+				if (!t++) s = x.lastIndex
+			} else if (t) {
+				if (!--t) {
+					a.push(str.slice(s, m.index))
+					if (!g) return a
+				}
+			}
+		}
+	} while (t && (x.lastIndex = s))
+
+	return a
+}
+export default matchRecursiveRegExp


### PR DESCRIPTION
The current version of the solution for identifying parameter types for strings containing "}" is incorrect
For example
```javascript
@param {{name: string}}
```
This pull request is trying to fix this bug 