### PR TITLE
Feature: parse ultiple components in the same file

### DIFF
--- a/packages/vue-docgen-api/src/main.ts
+++ b/packages/vue-docgen-api/src/main.ts
@@ -37,7 +37,11 @@ export async function parse(
 	filePath: string,
 	opts?: DocGenOptions | { [alias: string]: string }
 ): Promise<ComponentDoc> {
-	return parsePrimitive(async (doc, options) => await parseFile(doc, options), filePath, opts)
+	return (await parsePrimitive(async options => await parseFile(options), filePath, opts))[0]
+}
+
+export async function parseMulti(filePath: string, opts?: DocGenOptions): Promise<ComponentDoc[]> {
+	return parsePrimitive(async options => await parseFile(options), filePath, opts)
 }
 
 /**
@@ -50,26 +54,31 @@ export async function parseSource(
 	filePath: string,
 	opts?: DocGenOptions | { [alias: string]: string }
 ): Promise<ComponentDoc> {
-	return parsePrimitive(
-		async (doc, options) => await parseSourceLocal(doc, source, options),
+	return (await parsePrimitive(
+		async options => await parseSourceLocal(source, options),
 		filePath,
 		opts
-	)
+	))[0]
 }
 
 function isOptionsObject(opts: any): opts is DocGenOptions {
-	return !!opts && (!!opts.alias || opts.jsx !== undefined || !!opts.addScriptHandlers || !!opts.addTemplateHandlers)
+	return (
+		!!opts &&
+		(!!opts.alias ||
+			opts.jsx !== undefined ||
+			!!opts.addScriptHandlers ||
+			!!opts.addTemplateHandlers)
+	)
 }
 
 async function parsePrimitive(
-	createDoc: (doc: Documentation, opts: ParseOptions) => Promise<void>,
+	createDoc: (opts: ParseOptions) => Promise<Documentation[]>,
 	filePath: string,
 	opts?: DocGenOptions | { [alias: string]: string }
-): Promise<ComponentDoc> {
-	const doc = new Documentation()
+): Promise<ComponentDoc[]> {
 	const options: ParseOptions = isOptionsObject(opts)
 		? { ...opts, filePath }
 		: { filePath, alias: opts }
-	await createDoc(doc, options)
-	return doc.toObject()
+	const docs = await createDoc(options)
+	return docs.map(d => d.toObject())
 }

--- a/packages/vue-docgen-api/src/main.ts
+++ b/packages/vue-docgen-api/src/main.ts
@@ -9,7 +9,7 @@ import Documentation, {
 	Tag,
 	ParamTag
 } from './Documentation'
-import { DocGenOptions, parseFile, ParseOptions, parseSource as parseSourceLocal } from './parse'
+import { DocGenOptions, parseFile, ParseOptions, parseSource as _parseSource } from './parse'
 
 export { TemplateParserOptions } from './parse-template'
 export { ScriptHandler, TemplateHandler } from './parse'
@@ -29,7 +29,7 @@ export {
 }
 
 /**
- * Parse the components at filePath and return props, public methods, events and slots
+ * Parse the component at filePath and return props, public methods, events and slots
  * @param filePath absolute path of the parsed file
  * @param opts
  */
@@ -40,12 +40,19 @@ export async function parse(
 	return (await parsePrimitive(async options => await parseFile(options), filePath, opts))[0]
 }
 
+/**
+ * Parse all the components at filePath and returns an array of their
+ * props, public methods, events and slot
+ * @param filePath absolute path of the parsed file
+ * @param opts
+ */
 export async function parseMulti(filePath: string, opts?: DocGenOptions): Promise<ComponentDoc[]> {
 	return parsePrimitive(async options => await parseFile(options), filePath, opts)
 }
 
 /**
  * Parse the `source` assuming that it is located at `filePath` and return props, public methods, events and slots
+ * @param source source code to be parsed
  * @param filePath absolute path of the parsed file
  * @param opts
  */
@@ -55,7 +62,7 @@ export async function parseSource(
 	opts?: DocGenOptions | { [alias: string]: string }
 ): Promise<ComponentDoc> {
 	return (await parsePrimitive(
-		async options => await parseSourceLocal(source, options),
+		async options => await _parseSource(source, options),
 		filePath,
 		opts
 	))[0]

--- a/packages/vue-docgen-api/src/parse-script.ts
+++ b/packages/vue-docgen-api/src/parse-script.ts
@@ -71,14 +71,15 @@ async function executeHandlers(
 		compDefs.map(async name => {
 			const doc = documentation || new Documentation()
 			const compDef = componentDefinitions.get(name) as NodePath
-			// execute all handlers in order as order matters
+			// execute all prehandlers in order
 			await preHandlers.reduce(async (_, handler) => {
 				await _
 				return await handler(doc, compDef, ast, opt)
 			}, Promise.resolve())
 			await Promise.all(localHandlers.map(async handler => await handler(doc, compDef, ast, opt)))
 			// end with setting of exportname
-			// to avoid dependecies names bleeding on the main components
+			// to avoid dependencies names bleeding on the main components,
+			// do this step at the end of the function
 			doc.set('exportName', name)
 			return doc
 		})

--- a/packages/vue-docgen-api/src/parse-script.ts
+++ b/packages/vue-docgen-api/src/parse-script.ts
@@ -20,11 +20,11 @@ export type Handler = (
 
 export default async function parseScript(
 	source: string,
-	documentation: Documentation,
 	preHandlers: Handler[],
 	handlers: Handler[],
-	options: ParseOptions
-) {
+	options: ParseOptions,
+	documentation?: Documentation
+): Promise<Documentation[] | undefined> {
 	const plugins: ParserPlugin[] = options.lang === 'ts' ? ['typescript'] : ['flow']
 	if (options.jsx) {
 		plugins.push('jsx')
@@ -41,39 +41,46 @@ export default async function parseScript(
 		throw new Error(`${ERROR_MISSING_DEFINITION} on "${options.filePath}"`)
 	}
 
-	await executeHandlers(preHandlers, handlers, componentDefinitions, documentation, ast, options)
+	return await executeHandlers(
+		preHandlers,
+		handlers,
+		componentDefinitions,
+		documentation,
+		ast,
+		options
+	)
 }
 
 async function executeHandlers(
 	preHandlers: Handler[],
 	localHandlers: Handler[],
 	componentDefinitions: Map<string, NodePath>,
-	documentation: Documentation,
+	documentation: Documentation | undefined,
 	ast: bt.File,
 	opt: ParseOptions
-) {
+): Promise<Documentation[] | undefined> {
 	const compDefs = componentDefinitions
 		.keys()
 		.filter(name => name && (!opt.nameFilter || opt.nameFilter.indexOf(name) > -1))
 
-	if (compDefs.length > 1) {
-		throw 'vue-docgen-api: multiple exports in a component file are not handled yet by docgen'
+	if (documentation && compDefs.length > 1) {
+		throw 'vue-docgen-api: multiple exports in a component file are not handled by docgen.parse, Please use "docgen.parseMulti" intead'
 	}
 
 	return await Promise.all(
 		compDefs.map(async name => {
+			const doc = documentation || new Documentation()
 			const compDef = componentDefinitions.get(name) as NodePath
 			// execute all handlers in order as order matters
 			await preHandlers.reduce(async (_, handler) => {
 				await _
-				return await handler(documentation, compDef, ast, opt)
+				return await handler(doc, compDef, ast, opt)
 			}, Promise.resolve())
-			await Promise.all(
-				localHandlers.map(async handler => await handler(documentation, compDef, ast, opt))
-			)
+			await Promise.all(localHandlers.map(async handler => await handler(doc, compDef, ast, opt)))
 			// end with setting of exportname
 			// to avoid dependecies names bleeding on the main components
-			documentation.set('exportName', name)
+			doc.set('exportName', name)
+			return doc
 		})
 	)
 }

--- a/packages/vue-docgen-api/src/parse.ts
+++ b/packages/vue-docgen-api/src/parse.ts
@@ -59,11 +59,11 @@ export interface DocGenOptions {
  * @param {string} filePath path of the current file against whom to resolve the mixins
  * @returns {object} documentation object
  */
-export async function parseFile(documentation: Documentation, opt: ParseOptions) {
+export async function parseFile(opt: ParseOptions): Promise<Documentation[]> {
 	const source = await read(opt.filePath, {
 		encoding: 'utf-8'
 	})
-	return parseSource(documentation, source, opt)
+	return parseSource(source, opt)
 }
 
 /**
@@ -72,89 +72,96 @@ export async function parseFile(documentation: Documentation, opt: ParseOptions)
  * @param {string} filePath path of the current file against whom to resolve the mixins
  * @returns {object} documentation object
  */
-export async function parseSource(documentation: Documentation, source: string, opt: ParseOptions) {
-	// if the parsed component is the result of a mixin or an extends
-	documentation.setOrigin(opt)
+export async function parseSource(source: string, opt: ParseOptions): Promise<Documentation[]> {
+	// if jsx option is not mentionned, parse jsx in components
+	opt.jsx = opt.jsx === undefined ? true : opt.jsx
+
 	const singleFileComponent = /\.vue$/i.test(path.extname(opt.filePath))
-	let scriptSource: string | undefined
 
 	if (source === '') {
 		throw new Error(ERROR_EMPTY_DOCUMENT)
 	}
 
 	if (singleFileComponent) {
-		// use padding so that errors are displayed at the correct line
-		const parts = cacher(() => parseComponent(source, { pad: 'line' }), source)
+		return [await parseSFC(source, opt)]
+	} else {
+		const addScriptHandlers: ScriptHandler[] = opt.addScriptHandlers || []
+		opt.lang = /\.tsx?$/i.test(path.extname(opt.filePath)) ? 'ts' : 'js'
 
-		if (parts.customBlocks) {
-			const docsBlocks = parts.customBlocks
-				.filter(block => block.type === 'docs' && block.content && block.content.length)
-				.map(block => block.content.trim())
+		return (
+			(await parseScript(source, preHandlers, [...scriptHandlers, ...addScriptHandlers], opt)) || []
+		)
+	}
+}
 
-			if (docsBlocks.length) {
-				documentation.setDocsBlocks(docsBlocks)
-			}
+async function parseSFC(source: string, opt: ParseOptions): Promise<Documentation> {
+	const addScriptHandlers: ScriptHandler[] = opt.addScriptHandlers || []
+
+	const documentation = new Documentation()
+
+	// use padding so that errors are displayed at the correct line
+	const parts = cacher(() => parseComponent(source, { pad: 'line' }), source)
+
+	if (parts.customBlocks) {
+		const docsBlocks = parts.customBlocks
+			.filter(block => block.type === 'docs' && block.content && block.content.length)
+			.map(block => block.content.trim())
+
+		if (docsBlocks.length) {
+			documentation.setDocsBlocks(docsBlocks)
 		}
+	}
 
-		// get slots and props from template
-		if (parts.template) {
-			const extTemplSrc: string =
-				parts && parts.template && parts.template.attrs ? parts.template.attrs.src : ''
-			const extTemplSource =
-				extTemplSrc && extTemplSrc.length
-					? await read(path.resolve(path.dirname(opt.filePath), extTemplSrc), {
-							encoding: 'utf-8'
-					  })
-					: ''
-			if (extTemplSource.length) {
-				parts.template.content = extTemplSource
-			}
-			const addTemplateHandlers: TemplateHandler[] = opt.addTemplateHandlers || []
-			parseTemplate(
-				parts.template,
-				documentation,
-				[...templateHandlers, ...addTemplateHandlers],
-				opt.filePath
-			)
-		}
-
-		const extSrc: string = parts && parts.script && parts.script.attrs ? parts.script.attrs.src : ''
-		const extSource =
-			extSrc && extSrc.length
-				? await read(path.resolve(path.dirname(opt.filePath), extSrc), {
+	// get slots and props from template
+	if (parts.template) {
+		const extTemplSrc: string =
+			parts && parts.template && parts.template.attrs ? parts.template.attrs.src : ''
+		const extTemplSource =
+			extTemplSrc && extTemplSrc.length
+				? await read(path.resolve(path.dirname(opt.filePath), extTemplSrc), {
 						encoding: 'utf-8'
 				  })
 				: ''
-
-		scriptSource = extSource.length ? extSource : parts.script ? parts.script.content : undefined
-		opt.lang =
-			(parts.script && parts.script.attrs && parts.script.attrs.lang === 'ts') ||
-			/\.tsx?$/i.test(extSrc)
-				? 'ts'
-				: 'js'
-	} else {
-		scriptSource = source
-		opt.lang = /\.tsx?$/i.test(path.extname(opt.filePath)) ? 'ts' : 'js'
+		if (extTemplSource.length) {
+			parts.template.content = extTemplSource
+		}
+		const addTemplateHandlers: TemplateHandler[] = opt.addTemplateHandlers || []
+		parseTemplate(
+			parts.template,
+			documentation,
+			[...templateHandlers, ...addTemplateHandlers],
+			opt.filePath
+		)
 	}
 
-	if (scriptSource) {
-		// if jsx option is not mentionned, parse jsx in components
-		opt.jsx = opt.jsx === undefined ? true : opt.jsx
+	const extSrc: string = parts && parts.script && parts.script.attrs ? parts.script.attrs.src : ''
+	const extSource =
+		extSrc && extSrc.length
+			? await read(path.resolve(path.dirname(opt.filePath), extSrc), {
+					encoding: 'utf-8'
+			  })
+			: ''
 
-		const addScriptHandlers: ScriptHandler[] = opt.addScriptHandlers || []
-		if (scriptSource) {
-			await parseScript(
-				scriptSource,
-				documentation,
-				preHandlers,
-				[...scriptHandlers, ...addScriptHandlers],
-				opt
-			)
-		}
+	let scriptSource = extSource.length ? extSource : parts.script ? parts.script.content : undefined
+	opt.lang =
+		(parts.script && parts.script.attrs && parts.script.attrs.lang === 'ts') ||
+		/\.tsx?$/i.test(extSrc)
+			? 'ts'
+			: 'js'
+
+	if (scriptSource) {
+		await parseScript(
+			scriptSource,
+			preHandlers,
+			[...scriptHandlers, ...addScriptHandlers],
+			opt,
+			documentation
+		)
 	}
 
 	if (!documentation.get('displayName')) {
 		// a component should always have a display name
 		documentation.set('displayName', path.basename(opt.filePath).replace(/\.\w+$/, ''))
 	}
+	return documentation
 }

--- a/packages/vue-docgen-api/src/script-handlers/__tests__/extendsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/__tests__/extendsHandler.ts
@@ -50,11 +50,11 @@ describe('extendsHandler', () => {
 		].join('\n')
 		parseItExtends(src)
 		expect(parseFile).toHaveBeenCalledWith(
-			doc,
 			expect.objectContaining({
 				filePath: './component/full/path',
 				nameFilter: ['default']
-			})
+			}),
+			doc
 		)
 	})
 
@@ -67,11 +67,11 @@ describe('extendsHandler', () => {
 		].join('\n')
 		parseItExtends(src)
 		expect(parseFile).toHaveBeenCalledWith(
-			doc,
 			expect.objectContaining({
 				filePath: './component/full/path',
 				nameFilter: ['default']
-			})
+			}),
+			doc
 		)
 	})
 
@@ -84,11 +84,11 @@ describe('extendsHandler', () => {
 		].join('\n')
 		parseItExtends(src)
 		expect(parseFile).toHaveBeenCalledWith(
-			doc,
 			expect.objectContaining({
 				filePath: './component/full/path',
 				nameFilter: ['default']
-			})
+			}),
+			doc
 		)
 	})
 
@@ -101,11 +101,11 @@ describe('extendsHandler', () => {
 		].join('\n')
 		parseItExtends(src)
 		expect(parseFile).toHaveBeenCalledWith(
-			doc,
 			expect.objectContaining({
 				filePath: './component/full/path',
 				nameFilter: ['default']
-			})
+			}),
+			doc
 		)
 	})
 })

--- a/packages/vue-docgen-api/src/script-handlers/__tests__/mixinsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/__tests__/mixinsHandler.ts
@@ -60,11 +60,11 @@ describe('mixinsHandler', () => {
 			await mixinsHandler(doc, path, ast, { filePath: '' })
 		}
 		expect(mockParse).toHaveBeenCalledWith(
-			doc,
 			expect.objectContaining({
 				filePath: './component/full/path',
 				nameFilter: ['default']
-			})
+			}),
+			doc
 		)
 		done()
 	})
@@ -84,11 +84,11 @@ describe('mixinsHandler', () => {
 		}
 		await mixinsHandler(doc, path, ast, { filePath: '' })
 		expect(mockParse).toHaveBeenCalledWith(
-			doc,
 			expect.objectContaining({
 				filePath: './component/full/path',
 				nameFilter: ['default']
-			})
+			}),
+			doc
 		)
 		done()
 	})

--- a/packages/vue-docgen-api/src/script-handlers/extendsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/extendsHandler.ts
@@ -43,12 +43,15 @@ export default async function extendsHandler(
 				name: extendsFilePath[extendsVariableName].exportName,
 				path: fullFilePath
 			}
-			await parseFile(documentation, {
-				...opt,
-				filePath: fullFilePath,
-				nameFilter: [extendsFilePath[extendsVariableName].exportName],
-				extends: extendsVar
-			})
+			await parseFile(
+				{
+					...opt,
+					filePath: fullFilePath,
+					nameFilter: [extendsFilePath[extendsVariableName].exportName],
+					extends: extendsVar
+				},
+				documentation
+			)
 			extendsVar.name = documentation.get('displayName')
 		} catch (e) {
 			// eat the error

--- a/packages/vue-docgen-api/src/script-handlers/mixinsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/mixinsHandler.ts
@@ -56,12 +56,15 @@ export default async function mixinsHandler(
 					name: '<mixin/>',
 					path: fullFilePath
 				}
-				await parseFile(documentation, {
-					...opt,
-					filePath: fullFilePath,
-					nameFilter: vars,
-					mixin: mixinVar
-				})
+				await parseFile(
+					{
+						...opt,
+						filePath: fullFilePath,
+						nameFilter: vars,
+						mixin: mixinVar
+					},
+					documentation
+				)
 				mixinVar.name = documentation.get('displayName')
 			} catch (e) {
 				// eat the error

--- a/packages/vue-docgen-api/tests/components/jsfile/MyButton.js
+++ b/packages/vue-docgen-api/tests/components/jsfile/MyButton.js
@@ -57,3 +57,46 @@ export const Button = {
 		)
 	}
 }
+
+/**
+ * This is an input that represents another component extracted in the same file
+ */
+export const Input = {
+	name,
+
+	inheritAttrs: false,
+
+	props: {
+		variant: {
+			type: String,
+			default: 'solid'
+		},
+		variantColor: {
+			type: String,
+			default: 'gray'
+		},
+		size: {
+			type: [String, Number],
+			default: 'md'
+		},
+		isDisabled: {
+			type: Boolean
+		}
+	},
+
+	render(h) {
+		const childAttrs = {
+			disabled: this.isDisabled,
+			'aria-disabled': this.isDisabled
+		}
+
+		return h(
+			'input',
+			{
+				attrs: childAttrs,
+				on: this.$listeners
+			},
+			this.$slots.default
+		)
+	}
+}

--- a/packages/vue-docgen-api/tests/components/jsfile/button-js.test.ts
+++ b/packages/vue-docgen-api/tests/components/jsfile/button-js.test.ts
@@ -1,20 +1,32 @@
 import * as path from 'path'
 import { ComponentDoc } from '../../../src/Documentation'
-import { parse } from '../../../src/main'
+import { parseMulti } from '../../../src/main'
 
 const button = path.join(__dirname, './MyButton.js')
-let docButton: ComponentDoc
-describe('tests button with pug', () => {
+let docButton: ComponentDoc[]
+describe('tests button with pure javascript', () => {
 	beforeAll(async done => {
-		docButton = await parse(button, { nameFilter: 'Button' })
+		docButton = await parseMulti(button)
 		done()
 	})
 
 	it('should extract the export name', () => {
-		expect(docButton.exportName).toBe('Button')
+		expect(docButton[0].exportName).toBe('Button')
 	})
 
 	it('should have the correct content in the extracted definition', () => {
-		expect(docButton.description).toBe('This is a button that represents a javascript only component, not a vue SFC')
+		expect(docButton[0].description).toBe(
+			'This is a button that represents a javascript only component, not a vue SFC'
+		)
+	})
+
+	it('should extract the export name for input', () => {
+		expect(docButton[1].exportName).toBe('Input')
+	})
+
+	it('should have contain the input definition', () => {
+		expect(docButton[1].description).toBe(
+			'This is an input that represents another component extracted in the same file'
+		)
 	})
 })


### PR DESCRIPTION
I really dislike the mental burden of having multiple components in the same file.

It was too easy not to create it.
I still need to write the documentation though.

In order to keep backward compatibility I created another function called `parseMulti`

closes #664