### PR TITLE
Feature: allow extending documentation from node_modules

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -702,6 +702,29 @@ Defines the initial state of the props and methods tab:
 - `hide`: hide the tab and it can´t be toggled in the UI.
 - `expand`: expand the tab by default.
 
+## `validExtends`
+
+Type: `Function`, default: `fileFullPath => !/[\\/]node_modules[\\/]/.test(fileFullPath)`
+
+Function directly passed to `vue-docgen-api` to determine if a component that extends another should be parsed.
+
+The following lines will allow parsing extended components from node package `@my-library/components`.
+
+```javascript
+module.exports = {
+  validExtends(fullFilePath) {
+    return (
+      /[\\/]@my-library[\\/]components[\\/]/.test(fullFilePath) ||
+      !/[\\/]node_modules[\\/]/.test(fullFilePath)
+    )
+  }
+}
+```
+
+**NOTE** If `vue-docgen-api` fails to parse the targetted component, it will log a warning. It is not blocking but it is annoying.
+
+**NOTE** If you allow all of `node_modules` to try to be parsed, you might kill preformance. Use it responsibly.
+
 ## `verbose`
 
 Type: `Boolean`, default: `false`

--- a/docs/docs/Cookbook.md
+++ b/docs/docs/Cookbook.md
@@ -496,3 +496,23 @@ module.exports = {
 ```
 
 See [`template`](/Configuration.md#template) for more details.
+
+## How to use vue-styleguidist with multiple packages for components
+
+If your base components are in one package and the derived components are in another, you will want the documenattion to reflect extended components props in the exposed ones.
+
+Say you have a `BaseButton.vue` in a `@scoped/core` package that you extend into `IconButton.vue` in the `@scoped/extended` package, the `BaseButton.vue` props are not going to be documented with `IconButton.vue`. This can be what you want, or you could be missing a lot of props.
+
+Use the [validExtends](/Configuration.md#validExtends) option to allow parsing of extended components in other packages.
+
+```javascript
+module.exports = {
+  // Add the following function to your styleguide.config.js
+  validExtends(fullFilePath) {
+    return (
+      /[\\/]@scoped[\\/]core[\\/]/.test(fullFilePath) ||
+      !/[\\/]node_modules[\\/]/.test(fullFilePath)
+    )
+  }
+}
+```

--- a/docs/docs/Docgen.md
+++ b/docs/docs/Docgen.md
@@ -128,6 +128,28 @@ Same as `parse`, but allows for mulitple exported components in one file.
 
 **NOTE** Return type is `Array<ComponentDoc>` instead of `ComponentDoc`. Use `exportName` to differentiate the exports.
 
+### options `DocGenOptions`
+
+#### `alias`
+
+This is a mirror to the [wepbpack alias](https://webpack.js.org/configuration/resolve/#resolvealias) options. If you are using [alias in Webpack](https://webpack.js.org/configuration/resolve/#resolvealias) or paths in TypeScript, you should reflect this here..
+
+#### `resolve`
+
+`resolve` mirrors the [webpack option](https://webpack.js.org/configuration/resolve/#resolve) too. If you haev it in webpack or use baseDir in TypeScript, you should probably see how this one works.
+
+#### `addScriptHandler` and `addTemplateHandler`
+
+The custom additiona handlers allow you to add custom handlers to the parser. A handler can navigate and see custom objects that the standard parser would ignore.
+
+#### `validExtends`
+
+Function - Returns if an extended component should be parsed by docgen.
+
+**NOTE** If docgen fails to parse the targetted component, it will log a warning. It is non blocking but annoying.
+
+**NOTE** If you allow all of `node_modules` to try to be parsed, you might kill preformance. Use it responsibly.
+
 ## Documentation Object
 
 The `Documentation` class is the container of information before getting compiled. It is easily modified and accessed. To be used and exported, one can use the `toObject()` function.

--- a/packages/vue-docgen-api/src/main.ts
+++ b/packages/vue-docgen-api/src/main.ts
@@ -84,8 +84,16 @@ async function parsePrimitive(
 	opts?: DocGenOptions | { [alias: string]: string }
 ): Promise<ComponentDoc[]> {
 	const options: ParseOptions = isOptionsObject(opts)
-		? { ...opts, filePath }
-		: { filePath, alias: opts }
+		? {
+				validExtends: (fullFilePath: string) => !/[\\/]node_modules[\\/]/.test(fullFilePath),
+				...opts,
+				filePath
+		  }
+		: {
+				filePath,
+				alias: opts,
+				validExtends: (fullFilePath: string) => !/[\\/]node_modules[\\/]/.test(fullFilePath)
+		  }
 	const docs = await createDoc(options)
 	return docs.map(d => d.toObject())
 }

--- a/packages/vue-docgen-api/src/parse.ts
+++ b/packages/vue-docgen-api/src/parse.ts
@@ -16,6 +16,7 @@ const ERROR_EMPTY_DOCUMENT = 'The passed source is empty'
 export { ScriptHandler, TemplateHandler }
 
 export interface ParseOptions extends DocGenOptions, Descriptor {
+	validExtends: (fullFilePath: string) => boolean
 	filePath: string
 	/**
 	 * In what language is the component written
@@ -27,7 +28,7 @@ export interface ParseOptions extends DocGenOptions, Descriptor {
 export interface DocGenOptions {
 	/**
 	 * Which exported variables should be looked at
-	 * @default undefined - means treat all dependencies
+	 * @default undefined - means treat all exports
 	 */
 	nameFilter?: string[]
 	/**
@@ -51,6 +52,11 @@ export interface DocGenOptions {
 	 * @default true - if you do not disable it, babel will fail with `(<any>window).$`
 	 */
 	jsx?: boolean
+	/**
+	 * Should extended components be parsed?
+	 * @default `fullFilePath=>!/[\\/]node_modules[\\/]/.test(fullFilePath)`
+	 */
+	validExtends?: (fullFilePath: string) => boolean
 }
 
 /**

--- a/packages/vue-docgen-api/src/script-handlers/__tests__/extendsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/__tests__/extendsHandler.ts
@@ -37,7 +37,10 @@ describe('extendsHandler', () => {
 		const ast = babylon().parse(src)
 		const path = resolveExportedComponent(ast).get('default')
 		if (path) {
-			extendsHandler(doc, path, ast, { filePath: '' })
+			extendsHandler(doc, path, ast, {
+				filePath: '',
+				validExtends: (fullFilePath: string) => !/[\\/]node_modules[\\/]/.test(fullFilePath)
+			})
 		}
 	}
 

--- a/packages/vue-docgen-api/src/script-handlers/__tests__/mixinsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/__tests__/mixinsHandler.ts
@@ -57,7 +57,10 @@ describe('mixinsHandler', () => {
 		const ast = babelParser().parse(src)
 		const path = resolveExportedComponent(ast).get('default')
 		if (path) {
-			await mixinsHandler(doc, path, ast, { filePath: '' })
+			await mixinsHandler(doc, path, ast, {
+				filePath: '',
+				validExtends: (fullFilePath: string) => !/[\\/]node_modules[\\/]/.test(fullFilePath)
+			})
 		}
 		expect(mockParse).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -82,7 +85,10 @@ describe('mixinsHandler', () => {
 			done.fail()
 			return
 		}
-		await mixinsHandler(doc, path, ast, { filePath: '' })
+		await mixinsHandler(doc, path, ast, {
+			filePath: '',
+			validExtends: (fullFilePath: string) => !/[\\/]node_modules[\\/]/.test(fullFilePath)
+		})
 		expect(mockParse).toHaveBeenCalledWith(
 			expect.objectContaining({
 				filePath: './component/full/path',
@@ -107,7 +113,10 @@ describe('mixinsHandler', () => {
 			return
 		}
 		mockResolvePathFrom.mockReturnValue('foo/node_modules/component/full/path')
-		await mixinsHandler(doc, path, ast, { filePath: '' })
+		await mixinsHandler(doc, path, ast, {
+			filePath: '',
+			validExtends: (fullFilePath: string) => !/[\\/]node_modules[\\/]/.test(fullFilePath)
+		})
 		expect(mockParse).not.toHaveBeenCalled()
 		done()
 	})
@@ -126,7 +135,10 @@ describe('mixinsHandler', () => {
 			done.fail()
 			return
 		}
-		await mixinsHandler(doc, path, ast, { filePath: '' })
+		await mixinsHandler(doc, path, ast, {
+			filePath: '',
+			validExtends: (fullFilePath: string) => !/[\\/]node_modules[\\/]/.test(fullFilePath)
+		})
 		expect(mockParse).not.toHaveBeenCalled()
 		done()
 	})

--- a/packages/vue-docgen-api/src/script-handlers/extendsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/extendsHandler.ts
@@ -37,7 +37,7 @@ export default async function extendsHandler(
 
 	// only look for documentation in the current project not in node_modules
 	const fullFilePath = pathResolver(extendsFilePath[extendsVariableName].filePath)
-	if (!/[\\/]node_modules[\\/]/.test(fullFilePath)) {
+	if (opt.validExtends(fullFilePath)) {
 		try {
 			const extendsVar = {
 				name: extendsFilePath[extendsVariableName].exportName,

--- a/packages/vue-styleguidist/src/loaders/vuedoc-loader.ts
+++ b/packages/vue-styleguidist/src/loaders/vuedoc-loader.ts
@@ -49,7 +49,12 @@ export async function vuedocLoader(
 		modules = webpackConfig.resolve.modules
 	}
 	const defaultParser = async (file: string) =>
-		await parse(file, { alias, modules, jsx: config.jsxInComponents })
+		await parse(file, {
+			alias,
+			modules,
+			jsx: config.jsxInComponents,
+			validExtends: config.validExtends
+		})
 	const propsParser = config.propsParser || defaultParser
 
 	const docs = await propsParser(file)

--- a/packages/vue-styleguidist/src/scripts/schemas/config.ts
+++ b/packages/vue-styleguidist/src/scripts/schemas/config.ts
@@ -445,6 +445,12 @@ export default {
 		},
 		default: 'collapse'
 	},
+	validExtends: {
+		message: 'Should the passed filepath be parsed by docgen if mentionned extends',
+		type: 'function',
+		tstype: '(filePath: string) => boolean',
+		default: (fullFilePath: string) => !/[\\/]node_modules[\\/]/.test(fullFilePath)
+	},
 	verbose: {
 		message: 'Verbose',
 		description: 'Print debug information. Same as --verbose command line switch.',

--- a/packages/vue-styleguidist/src/types/StyleGuide.ts
+++ b/packages/vue-styleguidist/src/types/StyleGuide.ts
@@ -9,209 +9,213 @@ import { Example } from './Example'
 import { ComponentProps } from './Component'
 
 export interface StyleguidistContext extends loader.LoaderContext {
-    _styleguidist: StyleguidistConfig
+	_styleguidist: StyleguidistConfig
 }
 
 export interface StyleguidistConfig {
-    /**
-     * Your application static assets folder, will be accessible as / in the style guide dev server. 
-     */
-    assetsDir: string;
-    /**
-     * Should the styleguide try code splitting for better performance? NOte that you will need the proper transform in your babel config 
-     * @default true 
-     */
-    codeSplit: boolean;
-    compilerConfig: TransformOptions;
-    /**
-     * Where to find the components. Takes in a String or an Array of glob paths. Comma separated. 
-     */
-    components: () => (string | string[]) | string | string[];
-    configDir: string;
-    context: Record<string, any>;
-    contextDependencies: string[];
-    configureServer: (server: WebpackDevServer, env: string) => string;
-    /**
-     * Add a button on the top right of the code sections to copy to clipboard the current contents of the editor 
-     * @default false 
-     */
-    copyCodeButton: boolean;
-    /**
-     * Allows you to modify webpack config without any restrictions 
-     */
-    dangerouslyUpdateWebpackConfig: (server: Configuration, env: string) => Configuration;
-    /**
-     * Display each component with a default example, regardless of if there's a README or <docs/> block written. 
-     * @default false 
-     */
-    defaultExample: string;
-    editorConfig: {
+	/**
+	 * Your application static assets folder, will be accessible as / in the style guide dev server.
+	 */
+	assetsDir: string
+	/**
+	 * Should the styleguide try code splitting for better performance? NOte that you will need the proper transform in your babel config
+	 * @default true
+	 */
+	codeSplit: boolean
+	compilerConfig: TransformOptions
+	/**
+	 * Where to find the components. Takes in a String or an Array of glob paths. Comma separated.
+	 */
+	components: () => (string | string[]) | string | string[]
+	configDir: string
+	context: Record<string, any>
+	contextDependencies: string[]
+	configureServer: (server: WebpackDevServer, env: string) => string
+	/**
+	 * Add a button on the top right of the code sections to copy to clipboard the current contents of the editor
+	 * @default false
+	 */
+	copyCodeButton: boolean
+	/**
+	 * Allows you to modify webpack config without any restrictions
+	 */
+	dangerouslyUpdateWebpackConfig: (server: Configuration, env: string) => Configuration
+	/**
+	 * Display each component with a default example, regardless of if there's a README or <docs/> block written.
+	 * @default false
+	 */
+	defaultExample: string
+	editorConfig: {
 		theme: string
-	};
-    /**
-     * Defines the initial state of the props and methods tab 
-     * @default "collapse" 
-     */
-    exampleMode: EXPAND_MODE;
-    getComponentPathLine: (componentPath: string) => string;
-    getExampleFilename: (componentPath: string) => string;
-    /**
-     * @deprecated Use the theme property in the editorConfig option instead 
-     * @default "base16-light" 
-     */
-    highlightTheme: string;
-    /**
-     * What components to ignore. Can be an Array or String. Comma separated. 
-     */
-    ignore: string[];
-    /**
-     * Do documented components contain JSX syntax? Set this to `false` to restore compatibility with this TypeScript cast syntax: `<any>variable` instead of `variable as any`. 
-     * @default true 
-     */
-    jsxInComponents: boolean;
-    /**
-     * Allow exmaples to contain JSX syntax. Use proper JSX Vue component format in examples. 
-     * @default false 
-     */
-    jsxInExamples: boolean;
-    /**
-     * Register components on their examples only instead of globally Vue.components() 
-     * @default false 
-     */
-    locallyRegisterComponents: boolean;
-    /**
-     * @deprecated Use pagePerSection option instead 
-     * @default false 
-     */
-    navigation: boolean;
-    /**
-     * @deprecated Use renderRootJsx option instead 
-     */
-    mixins: string[];
-    logger: {
+	}
+	/**
+	 * Defines the initial state of the props and methods tab
+	 * @default "collapse"
+	 */
+	exampleMode: EXPAND_MODE
+	getComponentPathLine: (componentPath: string) => string
+	getExampleFilename: (componentPath: string) => string
+	/**
+	 * @deprecated Use the theme property in the editorConfig option instead
+	 * @default "base16-light"
+	 */
+	highlightTheme: string
+	/**
+	 * What components to ignore. Can be an Array or String. Comma separated.
+	 */
+	ignore: string[]
+	/**
+	 * Do documented components contain JSX syntax? Set this to `false` to restore compatibility with this TypeScript cast syntax: `<any>variable` instead of `variable as any`.
+	 * @default true
+	 */
+	jsxInComponents: boolean
+	/**
+	 * Allow exmaples to contain JSX syntax. Use proper JSX Vue component format in examples.
+	 * @default false
+	 */
+	jsxInExamples: boolean
+	/**
+	 * Register components on their examples only instead of globally Vue.components()
+	 * @default false
+	 */
+	locallyRegisterComponents: boolean
+	/**
+	 * @deprecated Use pagePerSection option instead
+	 * @default false
+	 */
+	navigation: boolean
+	/**
+	 * @deprecated Use renderRootJsx option instead
+	 */
+	mixins: string[]
+	logger: {
 		info(message: string): void
 		warn(message: string): void
 		debug(message: string): void
-	};
-    /**
-     * If this option is set to false, the styelguidist will not minimize the js at build. 
-     * @default true 
-     */
-    minimize: boolean;
-    /**
-     * The ID of a DOM element where Styleguidist mounts. 
-     * @default "rsg-root" 
-     */
-    mountPointId: string;
-    /**
-     * Render one section or component per page. If true, each section will be a single page. 
-     * @default false 
-     */
-    pagePerSection: boolean;
-    /**
-     * @default 500 
-     */
-    previewDelay: number;
-    printBuildInstructions: any;
-    printServerInstructions: any;
-    /**
-     * Display a progress bar while building 
-     * @default true 
-     */
-    progressBar: boolean;
-    propsParser: (file: string) => Promise<ComponentDoc>;
-    require: string[];
-    renderRootJsx: string;
-    /**
-     * Shows 'Fork Me' ribbon in the top-right corner. If ribbon key is present, then it's required to add url property; text property is optional. If you want to change styling of the ribbon, please, refer to the theme section in the documentation. 
-     */
-    ribbon: {
-		url: string,
+	}
+	/**
+	 * If this option is set to false, the styelguidist will not minimize the js at build.
+	 * @default true
+	 */
+	minimize: boolean
+	/**
+	 * The ID of a DOM element where Styleguidist mounts.
+	 * @default "rsg-root"
+	 */
+	mountPointId: string
+	/**
+	 * Render one section or component per page. If true, each section will be a single page.
+	 * @default false
+	 */
+	pagePerSection: boolean
+	/**
+	 * @default 500
+	 */
+	previewDelay: number
+	printBuildInstructions: any
+	printServerInstructions: any
+	/**
+	 * Display a progress bar while building
+	 * @default true
+	 */
+	progressBar: boolean
+	propsParser: (file: string) => Promise<ComponentDoc>
+	require: string[]
+	renderRootJsx: string
+	/**
+	 * Shows 'Fork Me' ribbon in the top-right corner. If ribbon key is present, then it's required to add url property; text property is optional. If you want to change styling of the ribbon, please, refer to the theme section in the documentation.
+	 */
+	ribbon: {
+		url: string
 		text: string
-	};
-    sections: Section[];
-    /**
-     * Dev server host name 
-     * @default "0.0.0.0" 
-     */
-    serverHost: string;
-    /**
-     * Dev server port 
-     * @default 6060 
-     */
-    serverPort: number;
-    /**
-     * @deprecated Use exampleMode option instead 
-     * @default false 
-     */
-    showCode: boolean;
-    /**
-     * @deprecated Use usageMode option instead 
-     * @default false 
-     */
-    showUsage: boolean;
-    /**
-     * Toggle sidebar visibility. Sidebar will be hidden when opening components or examples in isolation mode even if this value is set to true. When set to false, sidebar will always be hidden. 
-     * @default true 
-     */
-    showSidebar: boolean;
-    /**
-     * Avoid loading CodeMirror and reduce bundle size significantly, use prism.js for code highlighting. Warning: editor options will not be mapped over. 
-     * @default true 
-     */
-    simpleEditor: boolean;
-    /**
-     * Ignore components that don’t have an example file (as determined by getExampleFilename). These components won’t be accessible from other examples unless you manually require them. 
-     * @default false 
-     */
-    skipComponentsWithoutExample: boolean;
-    sortProps: (props: PropDescriptor[]) => PropDescriptor[];
-    styleguideComponents: { [name: string]: string };
-    /**
-     * Folder for static HTML style guide generated with `styleguidist build` command. 
-     * @default "styleguide" 
-     */
-    styleguideDir: string;
-    /**
-     * configures the prefix of the server and built urls. 
-     * @default "" 
-     */
-    styleguidePublicPath: string;
-    styles: any;
-    template: any;
-    theme: any;
-    /**
-     * Style guide title 
-     */
-    title: string;
-    updateDocs: (doc: ComponentProps, file: string) => ComponentProps;
-    updateExample: (props: Example, ressourcePath: string) => Example;
-    updateWebpackConfig: any;
-    /**
-     * Defines the initial state of the props and methods tab 
-     * @default "collapse" 
-     */
-    usageMode: EXPAND_MODE;
-    /**
-     * Print debug information. Same as --verbose command line switch. 
-     * @default false 
-     */
-    verbose: boolean;
-    /**
-     * The version # of the Styleguide 
-     */
-    version: string;
-    /**
-     * @deprecated Use renderRootJsx option instead 
-     */
-    vuex: any;
-    webpackConfig: Configuration;
+	}
+	sections: Section[]
+	/**
+	 * Dev server host name
+	 * @default "0.0.0.0"
+	 */
+	serverHost: string
+	/**
+	 * Dev server port
+	 * @default 6060
+	 */
+	serverPort: number
+	/**
+	 * @deprecated Use exampleMode option instead
+	 * @default false
+	 */
+	showCode: boolean
+	/**
+	 * @deprecated Use usageMode option instead
+	 * @default false
+	 */
+	showUsage: boolean
+	/**
+	 * Toggle sidebar visibility. Sidebar will be hidden when opening components or examples in isolation mode even if this value is set to true. When set to false, sidebar will always be hidden.
+	 * @default true
+	 */
+	showSidebar: boolean
+	/**
+	 * Avoid loading CodeMirror and reduce bundle size significantly, use prism.js for code highlighting. Warning: editor options will not be mapped over.
+	 * @default true
+	 */
+	simpleEditor: boolean
+	/**
+	 * Ignore components that don’t have an example file (as determined by getExampleFilename). These components won’t be accessible from other examples unless you manually require them.
+	 * @default false
+	 */
+	skipComponentsWithoutExample: boolean
+	sortProps: (props: PropDescriptor[]) => PropDescriptor[]
+	styleguideComponents: { [name: string]: string }
+	/**
+	 * Folder for static HTML style guide generated with `styleguidist build` command.
+	 * @default "styleguide"
+	 */
+	styleguideDir: string
+	/**
+	 * configures the prefix of the server and built urls.
+	 * @default ""
+	 */
+	styleguidePublicPath: string
+	styles: any
+	template: any
+	theme: any
+	/**
+	 * Style guide title
+	 */
+	title: string
+	updateDocs: (doc: ComponentProps, file: string) => ComponentProps
+	updateExample: (props: Example, ressourcePath: string) => Example
+	updateWebpackConfig: any
+	/**
+	 * Defines the initial state of the props and methods tab
+	 * @default "collapse"
+	 */
+	usageMode: EXPAND_MODE
+	/**
+	 * Should the passed filepath be parsed by docgen if mentionned extends
+	 */
+	validExtends: (filePath: string) => boolean
+	/**
+	 * Print debug information. Same as --verbose command line switch.
+	 * @default false
+	 */
+	verbose: boolean
+	/**
+	 * The version # of the Styleguide
+	 */
+	version: string
+	/**
+	 * @deprecated Use renderRootJsx option instead
+	 */
+	vuex: any
+	webpackConfig: Configuration
 }
 
 export interface StyleGuideObject {
-    sections: ProcessedSection[]
-    config: StyleguidistConfig
-    renderRootJsx: React.ReactNode
-    welcomeScreen: any
-    patterns: string[]
+	sections: ProcessedSection[]
+	config: StyleguidistConfig
+	renderRootJsx: React.ReactNode
+	welcomeScreen: any
+	patterns: string[]
 }


### PR DESCRIPTION
closes #606

- [x] allow customizing validity of a documented extended component in docgen
  - [x] add tests
  - [x] add docs
- [x] add a cookbook item to explain how to use a custom [propsParser](https://vue-styleguidist.github.io/Configuration.html#propsparser) to allow extending imported components in node_modules