### PR TITLE
fix: resolve imediately exported variables recursively

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "pretest": "yarn lint",
     "test": "yarn test:jest --maxWorkers=2 && yarn test:plugin",
     "test:jest": "jest",
+    "test:perf": "node ./packages/vue-docgen-api/tests/perf-test.js",
     "test:plugin": "rimraf ./test/cli-packages/* && jest --config=./jest.config.plugin.js --runInBand",
     "posttest": "yarn format",
     "test:coverage": "jest --coverage",

--- a/packages/vue-docgen-api/src/Documentation.ts
+++ b/packages/vue-docgen-api/src/Documentation.ts
@@ -120,13 +120,9 @@ export default class Documentation {
 	}
 
 	public setOrigin(origin: Descriptor) {
-		if (origin.extends) {
-			this.originExtendsMixin = { extends: origin.extends }
-		}
+		this.originExtendsMixin = origin.extends ? { extends: origin.extends } : {}
 
-		if (origin.mixin) {
-			this.originExtendsMixin = { mixin: origin.mixin }
-		}
+		this.originExtendsMixin = origin.mixin ? { mixin: origin.mixin } : {}
 	}
 
 	public setDocsBlocks(docsBlocks: string[]) {

--- a/packages/vue-docgen-api/src/parse.ts
+++ b/packages/vue-docgen-api/src/parse.ts
@@ -100,13 +100,14 @@ export async function parseSource(
 		documentation.setOrigin(opt)
 	}
 
+	let docs: Documentation[]
 	if (singleFileComponent) {
-		return [await parseSFC(documentation, source, opt)]
+		docs = [await parseSFC(documentation, source, opt)]
 	} else {
 		const addScriptHandlers: ScriptHandler[] = opt.addScriptHandlers || []
 		opt.lang = /\.tsx?$/i.test(path.extname(opt.filePath)) ? 'ts' : 'js'
 
-		const docs =
+		docs =
 			(await parseScript(
 				source,
 				preHandlers,
@@ -119,9 +120,12 @@ export async function parseSource(
 			// give a component a display name if we can
 			docs[0].set('displayName', path.basename(opt.filePath).replace(/\.\w+$/, ''))
 		}
-
-		return docs
 	}
+
+	if (documentation) {
+		documentation.setOrigin({})
+	}
+	return docs
 }
 
 async function parseSFC(

--- a/packages/vue-docgen-api/src/script-handlers/extendsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/extendsHandler.ts
@@ -33,7 +33,7 @@ export default async function extendsHandler(
 
 	const pathResolver = makePathResolver(originalDirName, opt.alias)
 
-	resolveImmediatelyExportedRequire(pathResolver, extendsFilePath)
+	await resolveImmediatelyExportedRequire(pathResolver, extendsFilePath)
 
 	await extendsFilePath[extendsVariableName].filePath.reduce(async (_, p) => {
 		const fullFilePath = pathResolver(p)

--- a/packages/vue-docgen-api/src/script-handlers/extendsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/extendsHandler.ts
@@ -33,7 +33,7 @@ export default async function extendsHandler(
 
 	const pathResolver = makePathResolver(originalDirName, opt.alias)
 
-	await resolveImmediatelyExportedRequire(pathResolver, extendsFilePath)
+	await resolveImmediatelyExportedRequire(pathResolver, extendsFilePath, opt.validExtends)
 
 	await extendsFilePath[extendsVariableName].filePath.reduce(async (_, p) => {
 		const fullFilePath = pathResolver(p)

--- a/packages/vue-docgen-api/src/script-handlers/mixinsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/mixinsHandler.ts
@@ -33,7 +33,7 @@ export default async function mixinsHandler(
 	// get all require / import statements
 	const mixinVarToFilePath = resolveRequired(astPath, mixinVariableNames)
 
-	resolveImmediatelyExportedRequire(pathResolver, mixinVarToFilePath)
+	await resolveImmediatelyExportedRequire(pathResolver, mixinVarToFilePath)
 
 	// get each doc for each mixin using parse
 	const files = new Map<string, string[]>()

--- a/packages/vue-docgen-api/src/script-handlers/mixinsHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/mixinsHandler.ts
@@ -33,7 +33,7 @@ export default async function mixinsHandler(
 	// get all require / import statements
 	const mixinVarToFilePath = resolveRequired(astPath, mixinVariableNames)
 
-	await resolveImmediatelyExportedRequire(pathResolver, mixinVarToFilePath)
+	await resolveImmediatelyExportedRequire(pathResolver, mixinVarToFilePath, opt.validExtends)
 
 	// get each doc for each mixin using parse
 	const files = new Map<string, string[]>()

--- a/packages/vue-docgen-api/src/utils/__tests__/adaptExportsToIEV.ts
+++ b/packages/vue-docgen-api/src/utils/__tests__/adaptExportsToIEV.ts
@@ -12,7 +12,7 @@ describe('adaptRequireWithIEV', () => {
 	})
 
 	it('should call the resolver', async done => {
-		await adaptRequireWithIEV(mockResolver, set)
+		await adaptRequireWithIEV(mockResolver, set, () => true)
 
 		expect(mockResolver).toHaveBeenCalledWith('my/path')
 		done()
@@ -20,7 +20,7 @@ describe('adaptRequireWithIEV', () => {
 
 	it('should not resolve anything if multiple path in filePath', async done => {
 		set.test.filePath.push('baz')
-		await adaptRequireWithIEV(mockResolver, set)
+		await adaptRequireWithIEV(mockResolver, set, () => true)
 
 		expect(mockResolver).not.toHaveBeenCalledWith()
 		done()

--- a/packages/vue-docgen-api/src/utils/__tests__/adaptExportsToIEV.ts
+++ b/packages/vue-docgen-api/src/utils/__tests__/adaptExportsToIEV.ts
@@ -11,16 +11,18 @@ describe('adaptRequireWithIEV', () => {
 		mockResolver = jest.fn()
 	})
 
-	it('should call the resolver', () => {
-		adaptRequireWithIEV(mockResolver, set)
+	it('should call the resolver', async done => {
+		await adaptRequireWithIEV(mockResolver, set)
 
 		expect(mockResolver).toHaveBeenCalledWith('my/path')
+		done()
 	})
 
-	it('should not resolve anything if multiple path in filePath', () => {
+	it('should not resolve anything if multiple path in filePath', async done => {
 		set.test.filePath.push('baz')
-		adaptRequireWithIEV(mockResolver, set)
+		await adaptRequireWithIEV(mockResolver, set)
 
 		expect(mockResolver).not.toHaveBeenCalledWith()
+		done()
 	})
 })

--- a/packages/vue-docgen-api/src/utils/adaptExportsToIEV.ts
+++ b/packages/vue-docgen-api/src/utils/adaptExportsToIEV.ts
@@ -14,13 +14,14 @@ const hash = require('hash-sum')
 
 export default async function recusiveAdaptExportsToIEV(
 	pathResolver: (path: string, originalDirNameOverride?: string) => string,
-	varToFilePath: ImportedVariableSet
+	varToFilePath: ImportedVariableSet,
+	validExtends: (fullFilePath: string) => boolean
 ) {
 	// resolve imediately exported variable as many layers as they are burried
 	let hashBefore: any
 	do {
 		hashBefore = hash(varToFilePath)
-		await adaptExportsToIEV(pathResolver, varToFilePath)
+		await adaptExportsToIEV(pathResolver, varToFilePath, validExtends)
 	} while (hashBefore !== hash(varToFilePath))
 }
 
@@ -37,7 +38,8 @@ export default async function recusiveAdaptExportsToIEV(
  */
 export async function adaptExportsToIEV(
 	pathResolver: (path: string, originalDirNameOverride?: string) => string,
-	varToFilePath: ImportedVariableSet
+	varToFilePath: ImportedVariableSet,
+	validExtends: (fullFilePath: string) => boolean
 ) {
 	// First, create a map from filepath to localName and exportedName
 	// key: filepath, content: {key: localName, content: exportedName}
@@ -66,6 +68,9 @@ export async function adaptExportsToIEV(
 				})
 				try {
 					const fullFilePath = pathResolver(filePath)
+					if (!validExtends(fullFilePath)) {
+						return
+					}
 					const source = await read(fullFilePath, {
 						encoding: 'utf-8'
 					})

--- a/packages/vue-docgen-api/tests/components/button/__snapshots__/button.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/button/__snapshots__/button.test.ts.snap
@@ -7,10 +7,6 @@ Object {
   "events": Array [
     Object {
       "description": "Success event.",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "success",
       "properties": Array [
         Object {
@@ -125,10 +121,6 @@ Object {
     },
     Object {
       "description": "Number of columns (1-12) the column should span.",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "span",
       "type": Object {
         "name": "string|number",
@@ -136,10 +128,6 @@ Object {
     },
     Object {
       "description": "Sm breakpoint and above",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "spanSm",
       "type": Object {
         "name": "string|number",
@@ -147,10 +135,6 @@ Object {
     },
     Object {
       "description": "Md breakpoint and above",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "spanMd",
       "type": Object {
         "name": "string|number",
@@ -162,10 +146,6 @@ Object {
         "value": "false",
       },
       "description": "The example props",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "example",
       "type": Object {
         "name": "boolean",
@@ -177,10 +157,6 @@ Object {
         "value": "'example model'",
       },
       "description": "Model example2",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "v-model",
       "tags": Object {
         "model": Array [
@@ -200,10 +176,6 @@ Object {
         "value": "16",
       },
       "description": "The example3 props",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "example3",
       "type": Object {
         "name": "number",
@@ -215,10 +187,6 @@ Object {
         "value": "() => () => null",
       },
       "description": "Add custom click actions.",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "onCustomClick",
       "tags": Object {
         "ignore": Array [
@@ -240,10 +208,6 @@ Object {
 }",
       },
       "description": "Function default",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "funcDefault",
       "type": Object {
         "name": "func",
@@ -258,20 +222,12 @@ Object {
       },
       "description": "Object or array defaults must be returned from
 a factory function",
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "propE",
       "type": Object {
         "name": "object",
       },
     },
     Object {
-      "mixin": Object {
-        "name": "multiMixin",
-        "path": "~/packages/vue-docgen-api/tests/mixins/multiMixin.js",
-      },
       "name": "prop1",
       "tags": Object {
         "ignore": Array [

--- a/packages/vue-docgen-api/tests/components/class-component/__snapshots__/button-class.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/class-component/__snapshots__/button-class.test.ts.snap
@@ -6,10 +6,6 @@ Object {
   "displayName": "ClassComponent",
   "events": Array [
     Object {
-      "mixin": Object {
-        "name": "mixin",
-        "path": "~/packages/vue-docgen-api/tests/components/class-component/mixin.ts",
-      },
       "name": "success",
       "type": Object {
         "names": Array [
@@ -21,10 +17,6 @@ Object {
   "exportName": "default",
   "methods": Array [
     Object {
-      "mixin": Object {
-        "name": "mixin",
-        "path": "~/packages/vue-docgen-api/tests/components/class-component/mixin.ts",
-      },
       "name": "onClick",
       "params": Array [
         Object {
@@ -57,10 +49,6 @@ Object {
       },
     },
     Object {
-      "mixin": Object {
-        "name": "mixin",
-        "path": "~/packages/vue-docgen-api/tests/components/class-component/mixin.ts",
-      },
       "name": "bundleHash",
       "type": Object {
         "name": "number",

--- a/packages/vue-docgen-api/tests/components/extended/InputTextDocumented.test.ts
+++ b/packages/vue-docgen-api/tests/components/extended/InputTextDocumented.test.ts
@@ -28,19 +28,20 @@ describe('tests InputTextDoc', () => {
 		expect(typeof docInputTextDoc.props !== 'undefined').toBe(true)
 	})
 	describe('props', () => {
-		it('should return two props in the documentation', () => {
+		it('should return props in the documentation', () => {
 			expect(docInputTextDoc.props && docInputTextDoc.props.map(p => p.name))
 				.toMatchInlineSnapshot(`
 			Array [
 			  "question",
 			  "importedProp",
 			  "otherMixinProp",
+			  "deep",
 			  "placeholder",
 			]
 		`)
 		})
 
-		it('should the component has placeholder of type string', () => {
+		it('should give the component a placeholder prop of type string', () => {
 			expect(getTestDescriptor(docInputTextDoc.props, 'placeholder').type).toEqual({
 				name: 'string'
 			})
@@ -56,6 +57,10 @@ describe('tests InputTextDoc', () => {
 			expect(docInputTextDoc.props && docInputTextDoc.props.map(p => p.name)).toContain(
 				'otherMixinProp'
 			)
+		})
+
+		it('should contain mixin imported prop from multiple layers of imports', () => {
+			expect(docInputTextDoc.props && docInputTextDoc.props.map(p => p.name)).toContain('deep')
 		})
 	})
 

--- a/packages/vue-docgen-api/tests/components/extended/InputTextDocumented.test.ts
+++ b/packages/vue-docgen-api/tests/components/extended/InputTextDocumented.test.ts
@@ -47,6 +47,10 @@ describe('tests InputTextDoc', () => {
 			})
 		})
 
+		it('should not give explicit prop no mixin of origin', () => {
+			expect(getTestDescriptor(docInputTextDoc.props, 'placeholder').mixin).toBeUndefined()
+		})
+
 		it('should contain mixin imported props', () => {
 			expect(docInputTextDoc.props && docInputTextDoc.props.map(p => p.name)).toContain(
 				'importedProp'

--- a/packages/vue-docgen-api/tests/components/extended/InputTextDocumented.vue
+++ b/packages/vue-docgen-api/tests/components/extended/InputTextDocumented.vue
@@ -7,13 +7,14 @@
 <script>
 import Base from './Base.vue'
 import { multi, other } from '../../mixins'
+import { deep } from '../../mixins'
 
 /**
  * Description InputTextDocumented
  */
 export default {
 	extends: Base,
-	mixins: [multi, other],
+	mixins: [multi, other, deep],
 	props: {
 		placeholder: {
 			type: String

--- a/packages/vue-docgen-api/tests/components/extended/__snapshots__/InputText.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/extended/__snapshots__/InputText.test.ts.snap
@@ -9,20 +9,12 @@ Object {
   "methods": undefined,
   "props": Array [
     Object {
-      "extends": Object {
-        "name": "Base",
-        "path": "~/packages/vue-docgen-api/tests/components/extended/Base.vue",
-      },
       "name": "question",
       "type": Object {
         "name": "undefined",
       },
     },
     Object {
-      "extends": Object {
-        "name": "Base",
-        "path": "~/packages/vue-docgen-api/tests/components/extended/Base.vue",
-      },
       "name": "placeholder",
       "type": Object {
         "name": "undefined",

--- a/packages/vue-docgen-api/tests/components/extended/__snapshots__/InputTextDocumented.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/extended/__snapshots__/InputTextDocumented.test.ts.snap
@@ -9,10 +9,6 @@ Object {
   "methods": undefined,
   "props": Array [
     Object {
-      "extends": Object {
-        "name": "Base",
-        "path": "~/packages/vue-docgen-api/tests/components/extended/Base.vue",
-      },
       "name": "question",
       "type": Object {
         "name": "undefined",
@@ -49,10 +45,6 @@ Object {
       },
     },
     Object {
-      "mixin": Object {
-        "name": "deep",
-        "path": "~/packages/vue-docgen-api/tests/mixins/another/deep.js",
-      },
       "name": "placeholder",
       "type": Object {
         "name": "string",

--- a/packages/vue-docgen-api/tests/components/extended/__snapshots__/InputTextDocumented.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/extended/__snapshots__/InputTextDocumented.test.ts.snap
@@ -40,8 +40,18 @@ Object {
     },
     Object {
       "mixin": Object {
-        "name": "otherNamed",
-        "path": "~/packages/vue-docgen-api/tests/mixins/otherNamed.js",
+        "name": "deep",
+        "path": "~/packages/vue-docgen-api/tests/mixins/another/deep.js",
+      },
+      "name": "deep",
+      "type": Object {
+        "name": "boolean",
+      },
+    },
+    Object {
+      "mixin": Object {
+        "name": "deep",
+        "path": "~/packages/vue-docgen-api/tests/mixins/another/deep.js",
       },
       "name": "placeholder",
       "type": Object {

--- a/packages/vue-docgen-api/tests/components/extended/__snapshots__/InputTextNatural.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/extended/__snapshots__/InputTextNatural.test.ts.snap
@@ -9,20 +9,12 @@ Object {
   "methods": undefined,
   "props": Array [
     Object {
-      "extends": Object {
-        "name": "Base",
-        "path": "~/packages/vue-docgen-api/tests/components/extended/Base.vue",
-      },
       "name": "question",
       "type": Object {
         "name": "undefined",
       },
     },
     Object {
-      "extends": Object {
-        "name": "Base",
-        "path": "~/packages/vue-docgen-api/tests/components/extended/Base.vue",
-      },
       "name": "placeholder",
       "type": Object {
         "name": "undefined",

--- a/packages/vue-docgen-api/tests/mixins/another/deep.js
+++ b/packages/vue-docgen-api/tests/mixins/another/deep.js
@@ -1,0 +1,5 @@
+export default {
+	props: {
+		deep: Boolean
+	}
+}

--- a/packages/vue-docgen-api/tests/mixins/multiNamed.js
+++ b/packages/vue-docgen-api/tests/mixins/multiNamed.js
@@ -1,6 +1,7 @@
-/* eslint-disable import/prefer-default-export */
 export const multi = {
 	props: {
 		importedProp: String
 	}
 }
+
+export { default as deep } from './another/deep'

--- a/packages/vue-docgen-api/tests/perf-test.js
+++ b/packages/vue-docgen-api/tests/perf-test.js
@@ -3,8 +3,7 @@ const glob = require('globby')
 const path = require('path')
 const { parse } = require('../')
 
-async function testPerformanceOfParse() {
-	const componentFiles = await glob(path.resolve(__dirname, './components/*/*.vue'))
+async function testPerformanceOfParse(componentFiles) {
 	const start = process.hrtime.bigint()
 	await Promise.all(
 		componentFiles.map(async compFile => {
@@ -25,14 +24,17 @@ async function testPerformanceOfParse() {
 	const final = process.hrtime.bigint()
 	return ((final - start) / 1000000n)
 }
+const ITERATIONS = 100n
 async function testPerformance100() {
-	let i = 100
+	let i = ITERATIONS
 	let time = 0n
+	const componentFiles = await glob('components/**/*.vue', {cwd: __dirname, absolute: true})
+
 	while (i--) {
-		const t = await testPerformanceOfParse()
-		console.log(i, t)
+		const t = await testPerformanceOfParse(componentFiles)
+		console.log("Case", ITERATIONS - i)
 		time += t
 	}
-	console.log(time / 100n)
+	console.log("Average :", time / ITERATIONS, "ms")
 }
 testPerformance100()


### PR DESCRIPTION
When resolvinf immediately exported variables 

```js
export foo from 'file/path'
```

I was not looking inside of `file/path` if it was an IEV as well which could lead to some unfortunate components not extended properly.

With this PR now I do.