### PR TITLE
Fix: make multiple exports safer

### DIFF
--- a/packages/vue-docgen-api/src/parse-script.ts
+++ b/packages/vue-docgen-api/src/parse-script.ts
@@ -65,6 +65,8 @@ function executeHandlers(
 	const compDefs = componentDefinitions
 		.keys()
 		.filter(name => name && (!opt.nameFilter || opt.nameFilter.indexOf(name) > -1))
+		// default component first so in multiple exports in parse it is returned
+		.sort((_, name2) => (name2 === 'default' ? 1 : 0))
 
 	if (!isSFC && documentation && compDefs.length > 1) {
 		throw 'vue-docgen-api: multiple exports in a component file are not handled by docgen.parse, Please use "docgen.parseMulti" instead'

--- a/packages/vue-docgen-api/src/parse-script.ts
+++ b/packages/vue-docgen-api/src/parse-script.ts
@@ -24,7 +24,7 @@ export default function parseScript(
 	handlers: Handler[],
 	options: ParseOptions,
 	documentation?: Documentation,
-	isSFC: boolean = false
+	forceSingleExport: boolean = false
 ): Promise<Documentation[] | undefined> {
 	const plugins: ParserPlugin[] = options.lang === 'ts' ? ['typescript'] : ['flow']
 	if (options.jsx) {
@@ -49,7 +49,7 @@ export default function parseScript(
 		documentation,
 		ast,
 		options,
-		isSFC
+		forceSingleExport
 	)
 }
 
@@ -60,7 +60,7 @@ function executeHandlers(
 	documentation: Documentation | undefined,
 	ast: bt.File,
 	opt: ParseOptions,
-	isSFC: boolean
+	forceSingleExport: boolean
 ): Promise<Documentation[] | undefined> {
 	const compDefs = componentDefinitions
 		.keys()
@@ -68,14 +68,18 @@ function executeHandlers(
 		// default component first so in multiple exports in parse it is returned
 		.sort((_, name2) => (name2 === 'default' ? 1 : 0))
 
-	if (!isSFC && documentation && compDefs.length > 1) {
+	if (forceSingleExport && compDefs.length > 1) {
 		throw 'vue-docgen-api: multiple exports in a component file are not handled by docgen.parse, Please use "docgen.parseMulti" instead'
 	}
 
 	return Promise.all(
 		compDefs.map(async name => {
+			// If there are multiple exports and an initial documentation,
+			// it means the doc is coming from an SFC template.
+			// Only enrich the doc attached to the default export
+			// NOTE: module.exports is normalized to default
 			const doc =
-				(isSFC ? (name === 'default' ? documentation : undefined) : documentation) ||
+				(compDefs.length > 1 && name !== 'default' ? undefined : documentation) ||
 				new Documentation()
 			const compDef = componentDefinitions.get(name) as NodePath
 			// execute all prehandlers in order

--- a/packages/vue-docgen-api/src/parse.ts
+++ b/packages/vue-docgen-api/src/parse.ts
@@ -112,7 +112,8 @@ export async function parseSource(
 				preHandlers,
 				[...scriptHandlers, ...addScriptHandlers],
 				opt,
-				documentation
+				documentation,
+				documentation !== undefined
 			)) || []
 
 		if (docs.length === 1 && !docs[0].get('displayName')) {

--- a/packages/vue-docgen-api/src/parseSFC.ts
+++ b/packages/vue-docgen-api/src/parseSFC.ts
@@ -72,7 +72,7 @@ export default async function parseSFC(
 				[...scriptHandlers, ...addScriptHandlers],
 				opt,
 				documentation,
-				true
+				initialDoc !== undefined
 		  )) || []
 		: // if there is only a template return the template's doc
 		  documentation

--- a/packages/vue-docgen-api/tests/components/jsfile/button-js.test.ts
+++ b/packages/vue-docgen-api/tests/components/jsfile/button-js.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import { ComponentDoc } from '../../../src/Documentation'
-import { parseMulti } from '../../../src/main'
+import { parseMulti, parse } from '../../../src/main'
 
 const button = path.join(__dirname, './MyButton.js')
 let docButton: ComponentDoc[]
@@ -48,5 +48,13 @@ describe('tests button with pure javascript', () => {
 		expect(docButton[1].description).toBe(
 			'This is an input that represents another component extracted in the same file'
 		)
+	})
+})
+
+describe('possible multiple export in parse function', () => {
+	it('should return Button when using parse', async done => {
+		const { exportName } = await parse(button)
+		expect(exportName).toBe('Button')
+		done()
 	})
 })

--- a/packages/vue-docgen-api/tests/components/multiple-exports/MyButton.vue
+++ b/packages/vue-docgen-api/tests/components/multiple-exports/MyButton.vue
@@ -103,6 +103,10 @@ export const Input = {
 		)
 	}
 }
+
+export default {
+	name: 'hello'
+}
 </script>
 
 <template>

--- a/packages/vue-docgen-api/tests/components/multiple-exports/multiple-exports.test.ts
+++ b/packages/vue-docgen-api/tests/components/multiple-exports/multiple-exports.test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 import { ComponentDoc } from '../../../src/Documentation'
-import { parseMulti } from '../../../src/main'
+import { parse, parseMulti } from '../../../src/main'
 
 const button = path.join(__dirname, './MyButton.vue')
 let docButton: ComponentDoc[]
@@ -48,5 +48,21 @@ describe('tests components with multiple exports', () => {
 		expect(docButton[1].description).toBe(
 			'This is an input that represents another component extracted in the same file'
 		)
+	})
+
+	it('should throw when using parse', () => {
+		expect(async () => {
+			await parse(button)
+		}).toThrow()
+	})
+
+	it('should match inline snapshot', () => {
+		expect(docButton.map(c => c.exportName)).toMatchInlineSnapshot(`
+		Array [
+		  "Button",
+		  "Input",
+		  "default",
+		]
+	`)
 	})
 })

--- a/packages/vue-docgen-api/tests/components/multiple-exports/multiple-exports.test.ts
+++ b/packages/vue-docgen-api/tests/components/multiple-exports/multiple-exports.test.ts
@@ -11,17 +11,17 @@ describe('tests components with multiple exports', () => {
 	})
 
 	it('should extract the export name', () => {
-		expect(docButton[0].exportName).toBe('Button')
+		expect(docButton[1].exportName).toBe('Button')
 	})
 
 	it('should have the correct content in the extracted definition', () => {
-		expect(docButton[0].description).toBe(
+		expect(docButton[1].description).toBe(
 			'This is a button that represents a javascript only component, not a vue SFC'
 		)
 	})
 
 	it('should export mixins prop', () => {
-		expect(docButton[0].props && docButton[0].props.map(p => p.name)).toMatchInlineSnapshot(`
+		expect(docButton[1].props && docButton[1].props.map(p => p.name)).toMatchInlineSnapshot(`
 		Array [
 		  "color",
 		  "id",
@@ -41,28 +41,29 @@ describe('tests components with multiple exports', () => {
 	})
 
 	it('should extract the export name for input', () => {
-		expect(docButton[1].exportName).toBe('Input')
+		expect(docButton[2].exportName).toBe('Input')
 	})
 
 	it('should have contain the input definition', () => {
-		expect(docButton[1].description).toBe(
+		expect(docButton[2].description).toBe(
 			'This is an input that represents another component extracted in the same file'
 		)
-	})
-
-	it('should throw when using parse', () => {
-		expect(async () => {
-			await parse(button)
-		}).toThrow()
 	})
 
 	it('should match inline snapshot', () => {
 		expect(docButton.map(c => c.exportName)).toMatchInlineSnapshot(`
 		Array [
+		  "default",
 		  "Button",
 		  "Input",
-		  "default",
 		]
 	`)
+	})
+})
+
+describe('possible multiple export in parse function', () => {
+	it('should return default when using parse', async done => {
+		const { exportName } = await parse(button)
+		expect(exportName).toBe('default')
 	})
 })

--- a/packages/vue-docgen-api/tests/components/multiple-exports/multiple-exports.test.ts
+++ b/packages/vue-docgen-api/tests/components/multiple-exports/multiple-exports.test.ts
@@ -65,5 +65,6 @@ describe('possible multiple export in parse function', () => {
 	it('should return default when using parse', async done => {
 		const { exportName } = await parse(button)
 		expect(exportName).toBe('default')
+		done()
 	})
 })


### PR DESCRIPTION
When parsing components using `parse`, if it contains multiple components, documenting `export default` and return it.

If parsing using `parseMulti`, default comes as the first entry.