### PR TITLE
Make it clear that the discord link requires Vue Land account

### DIFF
--- a/docs/docs/GettingStarted.md
+++ b/docs/docs/GettingStarted.md
@@ -57,5 +57,5 @@ See how to [document your components](Documenting.md)
 ## Have questions
 
 - [Read the cookbook](Cookbook.md)
-- [Ask on discord](https://discordapp.com/channels/325477692906536972/538786416092512278)
+- [Ask on discord](https://discordapp.com/channels/325477692906536972/538786416092512278) (requires [Vue Land](https://vue.land/) account)
 - [Post Questions on Github](https://github.com/vue-styleguidist/vue-styleguidist/issues/new?template=Question.md)


### PR DESCRIPTION
This wasn't clear to me originally, it just has a broken link if you aren't registered and logged into Vue Land.