### PR TITLE
fix(docgen):  fix ts array, intersection type print

### DIFF
--- a/examples/nuxtjs-ts-property-decorator/src/components/SomeComponent.vue
+++ b/examples/nuxtjs-ts-property-decorator/src/components/SomeComponent.vue
@@ -5,25 +5,33 @@
 </template>
 
 <script lang="ts">
-
 import { Vue, Component, Prop } from 'nuxt-property-decorator'
+
+interface Book {
+	name: string
+	desc: string
+}
 
 @Component
 export default class SomeComponent extends Vue {
 	/** Description for propA */
-	@Prop({ type: Number, default: 3}) readonly propA!: number
+	@Prop({ default: 3 })
+	readonly propA!: 'string literal' | 3 | Book | string[] | number[] | Book[] | Array<Book>
 
-  /**
-   * Description for mwthod. Don't froget to put `@public`.
+	@Prop({ default: 3 })
+	readonly propB!: 'string literal' & 3 & Book & string[] & number[] & Book[] & Array<Book>
+
+	/**
+	 * Description for mwthod. Don't froget to put `@public`.
 	 * @public
-   */
+	 */
 	public onClick(name: string) {
-    /**
-     * Success event when we click.
+		/**
+		 * Success event when we click.
 		 * @property {string} name description of name.
-     * @property {boolean} success always true.
-     */
-    this.$emit('success', { name, success: true })
+		 * @property {boolean} success always true.
+		 */
+		this.$emit('success', { name, success: true })
 	}
 }
 </script>


### PR DESCRIPTION
This is my first pr in this project, so I may be wrong.

Please, let me know if I don't follow contribution guide.

Currently, `vue-docgen-api` doesn't support proper union and intersection type.

This pr tries to fixes both.

I think it fixes #812 as well.

before (current version):
<img width="865" alt="Screen Shot 2020-04-14 at 4 08 14 PM" src="https://user-images.githubusercontent.com/10040154/79196063-54a5b300-7e6a-11ea-877f-0187304dc14e.png">

after (with this pr):
<img width="900" alt="Screen Shot 2020-04-14 at 4 09 13 PM" src="https://user-images.githubusercontent.com/10040154/79196073-57a0a380-7e6a-11ea-8593-18aaa38e5fc7.png">

