### PR TITLE
docs: add clarification to some requirements

### DIFF
--- a/docs/docs/Docgen.md
+++ b/docs/docs/Docgen.md
@@ -6,6 +6,7 @@
 
 - [API](#api)
 - [Architecture](#architecture)
+- [Custom Tags](#custom-tags)
 
 <!-- tocstop -->
 
@@ -299,5 +300,48 @@ export default function slotHandler(
     buttons.push(templateAst.attrsMap['name'])
     documentation.set('buttons', buttons)
   }
+}
+```
+## Custom Tags
+
+The API collects any custom doclets your code blocks contain. For a given slot, prop or root component documentation (the comment block before `export default`), any unrecognized doclet tags will get pushed to a separate `tags` object. For example, imagine that in your documentation, you wanted to give your documentation readers a textbox that had a two-way binding to your slot so they could preview their slot content in the actual component. You would want some mock data available for when the user hasn't entered anything. You could provide that mock data like so:
+
+```html
+<template>
+  <button>
+    <!--
+      @slot The text on the button
+      @mock Click me
+    -->
+    <slot />
+  </button>
+</template>
+```
+
+The output object for this component would show something like this:
+
+```js
+{
+  "displayName": "Button",
+  "exportName": "Button",
+  "tags": {}, // top-level comment block custom tags would go here
+  // ...
+  "props": [{
+    // ...
+    "tags": {}, // prop-level custom tags would go here
+    // ...
+  }]
+  // ...
+  "slots": [{
+    "name": "default",
+    "description": "The text on the button",
+    "tags": {
+      "mock": [{
+        "description": "Click me",
+        "title":"mock"
+      }]
+    }
+  }],
+  // ...
 }
 ```

--- a/docs/docs/Documenting.md
+++ b/docs/docs/Documenting.md
@@ -27,9 +27,7 @@ Vue styleguidist generates documentation for your components based on the commen
 
 Vue styleguidist will display the contents of your components’ JSDoc comment blocks.
 
-> **Note:** Components and documentation comments are parsed by default by the [vue-docgen-api](Docgen.md) library.
-
-> **Note:** You can change this behavior using [propsParser](/Configuration.md#propsparser) options.
+> **Note:** Components and documentation comments are parsed by default by the [vue-docgen-api](Docgen.md) library. You can change this behavior using [propsParser](/Configuration.md#propsparser) options.
 
 ```html
 <template>
@@ -76,7 +74,7 @@ Vue styleguidist will display the contents of your components’ JSDoc comment b
 </script>
 ```
 
-Note the use of the @displayName tag to change the displayed name of your component
+Note the use of the @displayName tag to change the displayed name of your component. This top-level comment block must come *before* the `export default` in your script tag.
 
 If you want to create a custom [v-model](https://vuejs.org/v2/guide/components.html#Customizing-Component-v-model), you have to add `model` tag in comment
 
@@ -231,6 +229,8 @@ example of a real documented slot
   <slot name="test" :icon="row.item.icon" :text="row.item.text" />
 </div>
 ```
+
+> **Note:** The docblock must be part of the **same** comment block. Multiple individual comments do not get parsed together.
 
 Another example of how to document bondings is in the `ScopedSlot` component in the basic example. Read the [code](https://github.com/vue-styleguidist/vue-styleguidist/blob/dev/examples/basic/src/components/ScopedSlot/ScopedSlot.vue) and see how it is rendered in the [live example](https://vue-styleguidist.github.io/basic/#scopedslot)
 


### PR DESCRIPTION
Just a few little changes to the docs, both documenting the addition of custom doclet tags, as well as clearing up some confusion on things that have tripped me up in the past.