### PR TITLE
fix(docgen): correctly extract default values (pending review)

### DIFF
--- a/packages/vue-docgen-api/src/script-handlers/__tests__/propHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/__tests__/propHandler.ts
@@ -303,7 +303,7 @@ describe('propHandler', () => {
 			expect(parserTest(src).defaultValue).toMatchInlineSnapshot(`
       Object {
         "func": true,
-        "value": "() => {
+        "value": "function() {
           return [\\"normal\\"];
       }",
       }
@@ -463,8 +463,8 @@ describe('propHandler', () => {
           props: {
             test: {
               type: Array,
-              default: function () { 
-				if (logger.mounted) { 
+              default: function () {
+				if (logger.mounted) {
 				  return []
 				} else {
 				  return undefined
@@ -488,8 +488,8 @@ describe('propHandler', () => {
           props: {
             test: {
               type: Array,
-              default: () => { 
-				if (logger.mounted) { 
+              default: () => {
+				if (logger.mounted) {
 				  return []
 				} else {
 				  return undefined
@@ -557,7 +557,7 @@ describe('propHandler', () => {
 
 				const testParsed = parserTest(src)
 				const defaultValue = removeWhitespaceForTest(testParsed.defaultValue)
-				expect(defaultValue).toMatchObject({ value: `(a,b)=>{return{a,b};}` })
+				expect(defaultValue).toMatchObject({ value: `function(a,b){return{a,b};}` })
 			})
 
 			it('old-school functions', () => {

--- a/packages/vue-docgen-api/src/script-handlers/__tests__/propHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/__tests__/propHandler.ts
@@ -290,24 +290,24 @@ describe('propHandler', () => {
 		it('should be ok with the default as a method', () => {
 			const src = [
 				'export default {',
-				'	props: {',
-				'		test: {',
-				'			default() {',
-				'				return ["normal"]',
-				'			}',
-				'		}',
-				'	}',
+				'  props: {',
+				'    test: {',
+				'      default() {',
+				'        return ["normal"]',
+				'      }',
+				'    }',
+				'  }',
 				'}'
 			].join('\n')
 
 			expect(parserTest(src).defaultValue).toMatchInlineSnapshot(`
-			Object {
-			  "func": true,
-			  "value": "() => {
-			    return [\\"normal\\"];
-			}",
-			}
-		`)
+      Object {
+        "func": true,
+        "value": "() => {
+          return [\\"normal\\"];
+      }",
+      }
+    `)
 		})
 
 		describe('propType object should extract return statement', () => {
@@ -316,12 +316,12 @@ describe('propHandler', () => {
         export default {
           props: {
             test: {
-							type: Object,
+              type: Object,
               default: () => ({ a: 1 })
             }
           }
         }
-				`
+        `
 				const testParsed = parserTest(src)
 				const defaultValue = removeWhitespaceForTest(testParsed.defaultValue)
 				expect(defaultValue).toMatchObject({ value: `{a:1}` })
@@ -332,7 +332,7 @@ describe('propHandler', () => {
         export default {
           props: {
             test: {
-							type: Object,
+              type: Object,
               default: () => { return { a: 1 } }
             }
           }
@@ -348,7 +348,7 @@ describe('propHandler', () => {
         export default {
           props: {
             test: {
-							type: Object,
+              type: Object,
               default () { return { a: 1 } }
             }
           }
@@ -364,7 +364,7 @@ describe('propHandler', () => {
         export default {
           props: {
             test: {
-							type: Object,
+              type: Object,
               default: function () { return { a: 1 } }
             }
           }
@@ -382,7 +382,7 @@ describe('propHandler', () => {
         export default {
           props: {
             test: {
-							type: Array,
+              type: Array,
               default: () => ([{a: 1}])
             }
           }
@@ -398,7 +398,7 @@ describe('propHandler', () => {
         export default {
           props: {
             test: {
-							type: Array,
+              type: Array,
               default: () => [{a: 1}]
             }
           }
@@ -414,7 +414,7 @@ describe('propHandler', () => {
         export default {
           props: {
             test: {
-							type: Array,
+              type: Array,
               default: () => { return [{a: 1}] }
             }
           }
@@ -430,7 +430,7 @@ describe('propHandler', () => {
         export default {
           props: {
             test: {
-							type: Array,
+              type: Array,
               default () { return [{a: 1}] }
             }
           }
@@ -446,7 +446,7 @@ describe('propHandler', () => {
         export default {
           props: {
             test: {
-							type: Array,
+              type: Array,
               default: function () { return [{a: 1}] }
             }
           }
@@ -462,12 +462,12 @@ describe('propHandler', () => {
 			it('arrow functions with parentheses', () => {
 				const src = [
 					'export default {',
-					'	props: {',
-					'		test: {',
-					'     type: Function,',
-					'			default: (a, b) => ({ a, b })',
-					'		}',
-					'	}',
+					'  props: {',
+					'    test: {',
+					'      type: Function,',
+					'      default: (a, b) => ({ a, b })',
+					'    }',
+					'  }',
 					'}'
 				].join('\n')
 
@@ -479,12 +479,12 @@ describe('propHandler', () => {
 			it('arrow functions', () => {
 				const src = [
 					'export default {',
-					'	props: {',
-					'		test: {',
-					'     type: Function,',
-					'			default: (a, b) => { return { a, b } }',
-					'		}',
-					'	}',
+					'  props: {',
+					'    test: {',
+					'      type: Function,',
+					'      default: (a, b) => { return { a, b } }',
+					'    }',
+					'  }',
 					'}'
 				].join('\n')
 
@@ -496,12 +496,12 @@ describe('propHandler', () => {
 			it('object methods', () => {
 				const src = [
 					'export default {',
-					'	props: {',
-					'		test: {',
-					'     type: [Function],',
-					'			default (a, b) { return { a, b } }',
-					'		}',
-					'	}',
+					'  props: {',
+					'    test: {',
+					'      type: [Function],',
+					'      default (a, b) { return { a, b } }',
+					'    }',
+					'  }',
 					'}'
 				].join('\n')
 
@@ -513,12 +513,12 @@ describe('propHandler', () => {
 			it('old-school functions', () => {
 				const src = [
 					'export default {',
-					'	props: {',
-					'		test: {',
-					'     type: [Function],',
-					'			default: function (a, b) { return { a, b } }',
-					'		}',
-					'	}',
+					'  props: {',
+					'    test: {',
+					'      type: [Function],',
+					'      default: function (a, b) { return { a, b } }',
+					'    }',
+					'  }',
 					'}'
 				].join('\n')
 
@@ -578,9 +578,9 @@ describe('propHandler', () => {
              * @model
              */
             value: {
-				required: true,
-				type: undefined
-			}
+        required: true,
+        type: undefined
+      }
           }
         }
         `
@@ -594,17 +594,17 @@ describe('propHandler', () => {
 		it('should set the v-model instead of value with model property', () => {
 			const src = `
         export default {
-		  model:{
-			prop: 'value'
-		  },
+      model:{
+      prop: 'value'
+      },
           props: {
             /**
              * Value of the field
              */
             value: {
-				required: true,
-				type: undefined
-			}
+        required: true,
+        type: undefined
+      }
           }
         }
         `
@@ -618,17 +618,17 @@ describe('propHandler', () => {
 		it('should not set the v-model instead of value if model property has only event', () => {
 			const src = `
         export default {
-		  model:{
-			event: 'change'
-		  },
+      model:{
+      event: 'change'
+      },
           props: {
             /**
              * Value of the field
              */
             value: {
-				required: true,
-				type: undefined
-			}
+        required: true,
+        type: undefined
+      }
           }
         }
         `
@@ -643,19 +643,19 @@ describe('propHandler', () => {
 	describe('@values tag parsing', () => {
 		it('should parse the @values tag as its own', () => {
 			const src = `
-	export default {
-	  props: {
-		/**
-		 * color of the component
-		 * @values dark, light
-		 * @author me
-		 */
-		color: {
-			type: string
-		}
-	  }
-	}
-	`
+  export default {
+    props: {
+    /**
+     * color of the component
+     * @values dark, light
+     * @author me
+     */
+    color: {
+      type: string
+    }
+    }
+  }
+  `
 			tester(src, {
 				description: 'color of the component',
 				values: ['dark', 'light'],
@@ -675,14 +675,14 @@ describe('propHandler', () => {
 	describe('typescript Vue.extends', () => {
 		it('should be ok with Prop', () => {
 			const src = `
-			  export default Vue.extend({
-				props: {
-				  tsvalue: {
-					type: [String, Number] as Prop<SelectOption['value']>,
-					required: true
-				  }
-				}
-			  });`
+        export default Vue.extend({
+        props: {
+          tsvalue: {
+          type: [String, Number] as Prop<SelectOption['value']>,
+          required: true
+          }
+        }
+        });`
 			tester(
 				src,
 				{
@@ -698,14 +698,14 @@ describe('propHandler', () => {
 
 		it('should parse values in TypeScript typings', () => {
 			const src = `
-			  export default Vue.extend({
-				props: {
-				  tsvalue: {
-					type: String as Prop<('foo' | 'bar')>,
-					required: true
-				  }
-				}
-			  });`
+        export default Vue.extend({
+        props: {
+          tsvalue: {
+          type: String as Prop<('foo' | 'bar')>,
+          required: true
+          }
+        }
+        });`
 			tester(
 				src,
 				{
@@ -722,14 +722,14 @@ describe('propHandler', () => {
 
 		it('should understand As anotations at the end of a prop definition', () => {
 			const src = `
-			export default Vue.extend({
-			  props: {
-				blockData: {
-					type: Array,
-					default: () => [],
-				} as PropOptions<SocialNetwork[]>,
-			  }
-			});`
+      export default Vue.extend({
+        props: {
+        blockData: {
+          type: Array,
+          default: () => [],
+        } as PropOptions<SocialNetwork[]>,
+        }
+      });`
 			tester(
 				src,
 				{
@@ -749,17 +749,17 @@ describe('propHandler', () => {
 	describe('@type', () => {
 		it('should use @type typings', () => {
 			const src = `
-			export default {
-			  props: {
-				/**
-				 * @type {{ bar: number, foo: string }}
-				 */
-				blockData: {
-					type: Object,
-					default: () => {},
-				},
-			  }
-			};`
+      export default {
+        props: {
+        /**
+         * @type {{ bar: number, foo: string }}
+         */
+        blockData: {
+          type: Object,
+          default: () => {},
+        },
+        }
+      };`
 			tester(src, {
 				type: {
 					name: '{ bar: number, foo: string }'
@@ -769,17 +769,17 @@ describe('propHandler', () => {
 
 		it('should extract values from @type typings', () => {
 			const src = `
-			export default {
-			  props: {
-				/**
-				 * @type { "bar + boo" | "foo & baz" }}
-				 */
-				blockData: {
-					type: String,
-					default: () => {},
-				},
-			  }
-			};`
+      export default {
+        props: {
+        /**
+         * @type { "bar + boo" | "foo & baz" }}
+         */
+        blockData: {
+          type: String,
+          default: () => {},
+        },
+        }
+      };`
 			tester(src, {
 				values: ['bar + boo', 'foo & baz'],
 				type: {

--- a/packages/vue-docgen-api/src/script-handlers/__tests__/propHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/__tests__/propHandler.ts
@@ -456,6 +456,56 @@ describe('propHandler', () => {
 				const defaultValue = removeWhitespaceForTest(testParsed.defaultValue)
 				expect(defaultValue).toMatchObject({ value: `[{a:1}]` })
 			})
+
+			it('should deal properly with multilple returns', () => {
+				const src = `
+        export default {
+          props: {
+            test: {
+              type: Array,
+              default: function () { 
+				if (logger.mounted) { 
+				  return []
+				} else {
+				  return undefined
+				}
+			  }
+            }
+          }
+        }
+        `
+				const testParsed = parserTest(src)
+				const defaultValue = removeWhitespaceForTest(testParsed.defaultValue)
+				expect(defaultValue).toMatchObject({
+					func: true,
+					value: `function(){if(logger.mounted){return[];}else{returnundefined;}}`
+				})
+			})
+
+			it('should deal properly with multilple returns in arrow functions', () => {
+				const src = `
+        export default {
+          props: {
+            test: {
+              type: Array,
+              default: () => { 
+				if (logger.mounted) { 
+				  return []
+				} else {
+				  return undefined
+				}
+			  }
+            }
+          }
+        }
+        `
+				const testParsed = parserTest(src)
+				const defaultValue = removeWhitespaceForTest(testParsed.defaultValue)
+				expect(defaultValue).toMatchObject({
+					func: true,
+					value: `()=>{if(logger.mounted){return[];}else{returnundefined;}}`
+				})
+			})
 		})
 
 		describe('propType function should keep function', () => {

--- a/packages/vue-docgen-api/src/script-handlers/classPropHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/classPropHandler.ts
@@ -93,7 +93,11 @@ export default async function classPropHandler(
 						if (!propPath.node.typeAnnotation) {
 							describeType(propsPath, propDescriptor)
 						}
-						describeDefault(propsPath, propDescriptor)
+						describeDefault(
+							propsPath,
+							propDescriptor,
+							(propDescriptor.type && propDescriptor.type.name) || ''
+						)
 						describeRequired(propsPath, propDescriptor)
 					}
 				}

--- a/packages/vue-docgen-api/src/script-handlers/propHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/propHandler.ts
@@ -388,8 +388,8 @@ export function describeDefault(
 			/* todo: add correct type info here ↓ */
 			const defaultBlockStatement = defaultArray[0].get('body')
 			const rawValue = recast.print(defaultBlockStatement).code
-			// the function should be reconstructed as arrow function, because Object Methods and arrow functions have the same `this`, whereas "old-school" functions do not.
-			const rawValueParsed = `(${params}) => ${rawValue.trim()}`
+			// the function should be reconstructed as "old-school" function, because they have the same handling of "this", whereas arrow functions do not.
+			const rawValueParsed = `function(${params}) ${rawValue.trim()}`
 			propDescriptor.defaultValue = {
 				func: true,
 				value: rawValueParsed

--- a/packages/vue-docgen-api/tests/components/button/__snapshots__/button.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/button/__snapshots__/button.test.ts.snap
@@ -146,10 +146,8 @@ Object {
     },
     Object {
       "defaultValue": Object {
-        "func": true,
-        "value": "() => {
-    return { message: 'hello' }
-}",
+        "func": false,
+        "value": "{ message: 'hello' }",
       },
       "description": "Object or array defaults must be returned from
 a factory function",

--- a/packages/vue-docgen-api/tests/components/button/button.test.ts
+++ b/packages/vue-docgen-api/tests/components/button/button.test.ts
@@ -193,8 +193,8 @@ describe('tests button', () => {
 		it('should value default propE to be a funtion', () => {
 			const dv = getTestDescriptor(docButton.props, 'propE').defaultValue
 			const functionNoSpaceNoReturn = dv ? dv.value.replace(/[ \n\r]/g, '') : ''
-			expect(functionNoSpaceNoReturn).toEqual(`()=>{return{message:'hello'}}`)
-			expect(dv ? dv.func : false).toBeTruthy()
+			expect(functionNoSpaceNoReturn).toEqual(`{message:'hello'}`)
+			expect(dv ? dv.func : true).toBeFalsy()
 		})
 
 		it('should example3 to be number', () => {

--- a/packages/vue-docgen-api/tests/components/grid-jsx/__snapshots__/grid-jsx.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/grid-jsx/__snapshots__/grid-jsx.test.ts.snap
@@ -141,10 +141,8 @@ Object {
     },
     Object {
       "defaultValue": Object {
-        "func": true,
-        "value": "function() {
-    return [{}]
-}",
+        "func": false,
+        "value": "[{}]",
       },
       "name": "images",
       "type": Object {

--- a/packages/vue-docgen-api/tests/components/grid-typescript/__snapshots__/grid-ts.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/grid-typescript/__snapshots__/grid-ts.test.ts.snap
@@ -166,10 +166,8 @@ Object {
     },
     Object {
       "defaultValue": Object {
-        "func": true,
-        "value": "function() {
-    return [{}]
-}",
+        "func": false,
+        "value": "[{}]",
       },
       "name": "images",
       "type": Object {

--- a/packages/vue-docgen-api/tests/components/grid/__snapshots__/grid.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/grid/__snapshots__/grid.test.ts.snap
@@ -141,10 +141,8 @@ Object {
     },
     Object {
       "defaultValue": Object {
-        "func": true,
-        "value": "function() {
-    return [{}]
-}",
+        "func": false,
+        "value": "[{}]",
       },
       "name": "images",
       "type": Object {


### PR DESCRIPTION
Fixes #852 

## Overview
I add an overview to see all the tests I added. Each time the "expected" result has its whitespaces and new lines stripped to check the expected result. This means: **these whitespaces and new lines are still there, but not being tested**.

<img width="1601" alt="image" src="https://user-images.githubusercontent.com/3253920/81621796-5000fa00-942a-11ea-936d-76562dd959a1.png">

> Please let me know if you don't agree with any of these expected results!!

## Questions

Two problems I ran into.

### 1. updated snaps

<img width="481" alt="image" src="https://user-images.githubusercontent.com/3253920/81496693-61e08100-92f4-11ea-8f0b-d8c1c46d791c.png">

A bunch of snapshots were updated. These need to be reviewed if these changes are for the better or not. If not, last commit can be reverted.

### 2. broken VSCode Jest tester...?

While my tests all passed in the terminal, I had some trouble with the VSCode tests. They stayed grey:
  
<img width="620" alt="Screenshot 2020-05-10 at 19 20 34" src="https://user-images.githubusercontent.com/3253920/81496739-c56aae80-92f4-11ea-9510-9da57ec5123d.png">

I'm not sure why, or if I should worry about it. :D

### 3. VSCode auto formatting

I don't know what part of my VSCode was different, but the eventual commits seem to have some weird spacing... Feel free to fix these by auto formatting again on your end!!

<img width="468" alt="image" src="https://user-images.githubusercontent.com/3253920/81511966-f9c38680-9357-11ea-9889-a0f5090b8074.png">

<img width="606" alt="image" src="https://user-images.githubusercontent.com/3253920/81511968-fcbe7700-9357-11ea-9c95-e26623152129.png">
