### PR TITLE
docs: fixed the url from Components.html to Configuration.html

### DIFF
--- a/docs/docs/Components.md
+++ b/docs/docs/Components.md
@@ -32,7 +32,7 @@ But will ignore tests:
 
 ## Loading and exposing components
 
-Styleguidist, by default, _loads_ your components and _exposes_ them globally for your examples to consume. You can use [locallyRegisterComponents](/Configuration.md#locallyRegisterComponents) to avoid global registration. This loads a documented component only in the examples that are in its attached `ReadMe.md` file or `<docs>` block.
+Styleguidist, by default, _loads_ your components and _exposes_ them globally for your examples to consume. You can use [locallyRegisterComponents](/Configuration.md#locallyregistercomponents) to avoid global registration. This loads a documented component only in the examples that are in its attached `ReadMe.md` file or `<docs>` block.
 
 ## Sections
 


### PR DESCRIPTION
I have known the bug #967 How to fixed.