### PR TITLE
fix: no undefined consts

### DIFF
--- a/packages/vue-styleguidist/src/client/rsg-components/ExamplePlaceholder/ExamplePlaceholderRenderer.js
+++ b/packages/vue-styleguidist/src/client/rsg-components/ExamplePlaceholder/ExamplePlaceholderRenderer.js
@@ -4,7 +4,7 @@ import map from 'lodash/map'
 import { getDefaultExample } from 'vue-inbrowser-compiler-utils'
 import Styled from 'rsg-components/Styled'
 import Markdown from 'rsg-components/Markdown'
-import { DOCS_DOCUMENTING } from '../../../scripts/consts'
+import consts from '../../../scripts/consts'
 import { DocumentedComponentContext } from '../VsgReactComponent/ReactComponent'
 
 const styles = ({ fontFamily, fontSize, color }) => ({
@@ -93,7 +93,7 @@ You can also add examples and documentation in the \`<docs>\` block of your \`.v
 
 You may need to **restart** the style guide server after adding an example file.
 
-Read more in the [documenting components guide](${DOCS_DOCUMENTING}).
+Read more in the [documenting components guide](${consts.DOCS_DOCUMENTING}).
 					`}
 				/>
 			)

--- a/packages/vue-styleguidist/src/client/rsg-components/VsgStyleGuide/StyleGuideRenderer.js
+++ b/packages/vue-styleguidist/src/client/rsg-components/VsgStyleGuide/StyleGuideRenderer.js
@@ -6,7 +6,7 @@ import Styled from 'rsg-components/Styled'
 import cx from 'classnames'
 import Ribbon from 'rsg-components/Ribbon'
 import Version from 'rsg-components/Version'
-import { HOMEPAGE } from '../../../scripts/consts'
+import consts from '../../../scripts/consts'
 
 const styles = ({ color, sidebarWidth, mq, space, maxWidth }) => ({
 	root: {
@@ -57,7 +57,7 @@ export function StyleGuideRenderer({ classes, title, version, children, toc, has
 		<div className={cx(classes.root, hasSidebar && classes.hasSidebar)}>
 			<main className={classes.content}>
 				{children}
-				<StyleguideFooter homepageUrl={HOMEPAGE} />
+				<StyleguideFooter homepageUrl={consts.HOMEPAGE} />
 			</main>
 			{hasSidebar && (
 				<div className={classes.sidebar}>

--- a/packages/vue-styleguidist/src/client/rsg-components/Welcome/WelcomeRenderer.js
+++ b/packages/vue-styleguidist/src/client/rsg-components/Welcome/WelcomeRenderer.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Markdown from 'rsg-components/Markdown'
 import Styled from 'rsg-components/Styled'
-import { DOCS_COMPONENTS } from '../../../scripts/consts'
+import consts from '../../../scripts/consts'
 
 const styles = ({ space, maxWidth }) => ({
 	root: {
@@ -29,7 +29,7 @@ Create **styleguide.config.js** file in your project root directory like this:
       components: 'src/components/**/*.vue'
     };
 
-Read more in the [locating components guide](${DOCS_COMPONENTS}).
+Read more in the [locating components guide](${consts.DOCS_COMPONENTS}).
 				`}
 			/>
 		</div>


### PR DESCRIPTION
This fixes an issue where the homepageUrl is always pointed to `undefined`:

```
Warning: Failed prop type: The prop `homepageUrl` is marked as required in `StyleguideFooterRenderer`, but its value is `undefined`.
```

In addition to the above case, this also fixes the similar issues I found in this repo while investigating.