### PR TITLE
chore(deps): suppress unnecessary peerDeps warning

### DIFF
--- a/packages/vue-styleguidist/package.json
+++ b/packages/vue-styleguidist/package.json
@@ -91,6 +91,11 @@
 		"vue-template-compiler": ">=2.0.0",
 		"webpack": ">=4"
 	},
+	"peerDependenciesMeta": {
+		"pug": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"@babel/types": "^7.5.5",
 		"@testing-library/react": "^9.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -979,7 +979,7 @@ importers:
     specifiers:
       '@vue/cli': ^4.4.6
       '@vue/cli-test-utils': ^4.4.6
-      vue-styleguidist: ^4.32.2
+      vue-styleguidist: ^4.32.3
       webpack-merge: ^4.2.1
   packages/vue-docgen-api:
     dependencies:


### PR DESCRIPTION
- `peerDependenciesMeta` is supported in [`npm`](https://github.com/npm/cli/pull/224), [`pnpm`](https://pnpm.js.org/en/package_json#peerdependenciesmeta), [`yarn`](https://classic.yarnpkg.com/en/docs/package-json/#toc-peerdependenciesmeta), and [`yarn 2`](https://yarnpkg.com/configuration/manifest#peerDependenciesMeta)
- `pug` is not a necessary peer dependency, it should not need to be installed if `lang="pug"` is not used