### PR TITLE
Fix 'cd' path in examples/vuecli3-class-pug-ts/README.md

### DIFF
--- a/examples/vuecli3-class-pug-ts/README.md
+++ b/examples/vuecli3-class-pug-ts/README.md
@@ -6,7 +6,7 @@ How to start locally:
 
 ```
 git clone https://github.com/vue-styleguidist/vue-styleguidist.git
-cd vue-styleguidist/examples/pug-ts-cli-class
+cd vue-styleguidist/examples/vuecli3-class-pug-ts
 npm install
 npm run styleguide
 ```


### PR DESCRIPTION
I've noticed that in the README file a different name for the example is used than the current one.