### PR TITLE
fix: resolve #1042 add basic support for aliases in external src

### DIFF
--- a/packages/vue-docgen-api/README.md
+++ b/packages/vue-docgen-api/README.md
@@ -113,7 +113,9 @@ parseMulti(filePath: string, options: DocGenOptions): Promise<ComponentDoc[]>;
 
 #### `alias`
 
-This is a mirror to the [wepbpack alias](https://webpack.js.org/configuration/resolve/#resolvealias) options. If you are using [alias in Webpack](https://webpack.js.org/configuration/resolve/#resolvealias) or paths in TypeScript, you should reflect this here..
+This is a mirror to the [wepbpack alias](https://webpack.js.org/configuration/resolve/#resolvealias) options. If you are using [alias in Webpack](https://webpack.js.org/configuration/resolve/#resolvealias) or paths in TypeScript, you should reflect this here.
+
+Keep in mind aliases are not resolved adopting the same implementation as webpack, but as simple path replacement. Aliases are resolved as soon as they match in the file path, bailing out of further tests. This means the order in which aliases are defined matters. E.g. an alias `@templates` mapped to `styleguide/templates/` should be defined earlier than the alias `@` (mapped to `src` ) to avoid `@templates/component` being resolved as `srctemplates/component` instead of `styleguide/templates/component`.
 
 #### `modules`
 

--- a/packages/vue-docgen-api/src/parseSFC.ts
+++ b/packages/vue-docgen-api/src/parseSFC.ts
@@ -24,7 +24,16 @@ export default async function parseSFC(
 
 	// get slots and props from template
 	if (parts.template) {
-		const extTemplSrc = parts?.template?.attrs?.src
+		let extTemplSrc = parts?.template?.attrs?.src
+
+		// resolve aliases (does not support context and module resolution as in webpack,
+		// which would require the enhanced-resolve package)
+		if (opt.alias && Object.keys(opt.alias).length && typeof extTemplSrc === 'string') {
+			extTemplSrc = Object.entries(opt.alias).reduce(
+				(resolvedPath, [alias, aliasMapping]) => resolvedPath.replace(alias, aliasMapping),
+				extTemplSrc
+			)
+		}
 
 		const extTemplSource =
 			extTemplSrc && typeof extTemplSrc === 'string' && extTemplSrc.length


### PR DESCRIPTION
Hello @elevatebart 

this PR fixes the missing support for aliases when resolving external sources in vue SFCs. 
this is a basic implementation: it relies on simple strings replacement, avoiding the complexities of integrating https://github.com/webpack/enhanced-resolve and having to support the whole set of options available when resolving modules. 

Aliases are resolved top to bottom (the order in which keys are defined, which matters when inheriting webpack aliases whose configuration go through several merges). This means `@identifier` must be declared before `@` to avoid `src='@identifier'` to be resolved too early.

✅ the implementation supports simple aliases, e.g.
```js
/* webpack section in vue.config.js or styleguide.config.js */
resolve: {
    alias: {
       `@`: path.resolve(__dirname, 'src')
    }
}

/* SFC */
<template src="@/components/MyComponent.html" />
```

🛑 but module based aliases or complex configurations won't, e.g.

```js
/* SFC */
<template src="package/dist/MyComponent.html" />
```

I updated the documentation with a short note about this known limitation.