### PR TITLE
fix(docgen): ensure pug renders template using html doctype

### DIFF
--- a/packages/vue-docgen-api/src/parse-template.ts
+++ b/packages/vue-docgen-api/src/parse-template.ts
@@ -27,8 +27,8 @@ export default function parseTemplate(
 		const source =
 			tpl.attrs && tpl.attrs.lang === 'pug'
 				? pug.render(tpl.content.trim(), {
-						...pugOptions,
 						doctype: 'html',
+						...pugOptions,
 						filename: filePath
 					})
 				: tpl.content

--- a/packages/vue-docgen-api/src/parse-template.ts
+++ b/packages/vue-docgen-api/src/parse-template.ts
@@ -26,7 +26,11 @@ export default function parseTemplate(
 	if (tpl && tpl.content) {
 		const source =
 			tpl.attrs && tpl.attrs.lang === 'pug'
-				? pug.render(tpl.content.trim(), { ...pugOptions, filename: filePath })
+				? pug.render(tpl.content.trim(), {
+						...pugOptions,
+						doctype: 'html',
+						filename: filePath
+					})
 				: tpl.content
 
 		const ast: RootNode = cacher(() => parse(source, { comments: true }), source)


### PR DESCRIPTION
avoid mirroring of boolean attributes causing v-else to fail compilation #1052