### PR TITLE
fix(docgen): use real prop name instead of v-model

### DIFF
--- a/packages/vue-docgen-api/README.md
+++ b/packages/vue-docgen-api/README.md
@@ -457,7 +457,7 @@ const componentDoc = {
           }
         ]
       },
-      name: 'v-model',
+      name: 'value',
       type: {
         name: 'string'
       }

--- a/packages/vue-docgen-api/src/Documentation.ts
+++ b/packages/vue-docgen-api/src/Documentation.ts
@@ -71,12 +71,9 @@ export default class Documentation {
 	}
 
 	public getPropDescriptor(propName: string): PropDescriptor {
-		const vModelDescriptor = this.propsMap.get('v-model')
-		return vModelDescriptor && vModelDescriptor.name === propName
-			? vModelDescriptor
-			: this.getDescriptor(propName, this.propsMap, () => ({
-					name: propName
-			  }))
+		return this.getDescriptor(propName, this.propsMap, () => ({
+			name: propName
+		}))
 	}
 
 	public getMethodDescriptor(methodName: string): MethodDescriptor {

--- a/packages/vue-docgen-api/src/script-handlers/__tests__/propHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/__tests__/propHandler.ts
@@ -395,7 +395,7 @@ describe('propHandler', () => {
 	})
 
 	describe('v-model', () => {
-		it('should set the @model property as v-model instead of test', () => {
+		it('should set the @model property as test instead of v-model', () => {
 			const src = `
         export default {
           props: {
@@ -406,15 +406,15 @@ describe('propHandler', () => {
             test: String
           }
         }
-        `
+			`
 			expect(parserTest(src)).toMatchObject({
 				description: 'test description'
 			})
-			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('test')
-			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('v-model')
+			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('test')
+			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('v-model')
 		})
 
-		it('should set the @model property as v-model instead of value even with a type', () => {
+		it('should set the @model property as value instead of value even with a type', () => {
 			const src = `
         export default {
           props: {
@@ -423,41 +423,41 @@ describe('propHandler', () => {
              * @model
              */
             value: {
-        required: true,
-        type: undefined
-      }
+              required: true,
+              type: undefined
+            }
           }
         }
-        `
+			`
 			expect(parserTest(src)).toMatchObject({
 				description: 'Binding from v-model'
 			})
-			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('value')
-			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('v-model')
+			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('value')
+			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('v-model')
 		})
 
-		it('should set the v-model instead of value with model property', () => {
+		it('should set the value with model property instead of v-model', () => {
 			const src = `
         export default {
-      model:{
-      prop: 'value'
-      },
+          model: {
+            prop: 'value'
+          },
           props: {
             /**
              * Value of the field
              */
             value: {
-        required: true,
-        type: undefined
-      }
+              required: true,
+              type: undefined
+            }
           }
         }
-        `
+			`
 			expect(parserTest(src)).toMatchObject({
 				description: 'Value of the field'
 			})
-			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('value')
-			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('v-model')
+			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('value')
+			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('v-model')
 		})
 
 		it('should not set the v-model instead of value if model property has only event', () => {
@@ -525,7 +525,7 @@ describe('propHandler', () => {
 			type: String,
 			validator(va){
 				return ['dark', 'light', 'red', 'blue'].indexOf(va) > -1
-			} 
+			}
         }
     }
   }
@@ -539,7 +539,7 @@ describe('propHandler', () => {
     props: {
         color: {
 			type: String,
-			validator: (va) => 
+			validator: (va) =>
 				['dark', 'light', 'red', 'blue'].indexOf(va) > -1
         }
     }

--- a/packages/vue-docgen-api/src/script-handlers/propHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/propHandler.ts
@@ -46,8 +46,6 @@ export default function propHandler(documentation: Documentation, path: NodePath
 			return Promise.resolve()
 		}
 
-		const modelPropertyName = getModelPropName(path)
-
 		const propsValuePath = propsPath[0].get('value')
 
 		if (bt.isObjectExpression(propsValuePath.node)) {
@@ -75,11 +73,8 @@ export default function propHandler(documentation: Documentation, path: NodePath
 				if (!propertyName) {
 					return
 				}
-				const isPropertyModel =
-					jsDocTags.some(t => t.title === 'model') || propertyName === modelPropertyName
-				const propName = isPropertyModel ? 'v-model' : propertyName
 
-				const propDescriptor = documentation.getPropDescriptor(propName)
+				const propDescriptor = documentation.getPropDescriptor(propertyName)
 
 				const propValuePath = prop.get('value')
 
@@ -473,34 +468,4 @@ export function extractValuesFromTags(propDescriptor: PropDescriptor) {
 
 		delete propDescriptor.tags.values
 	}
-}
-
-/**
- * extract the property model.prop from the component object
- * @param path component NodePath
- * @returns name of the model prop, null if none
- */
-function getModelPropName(path: NodePath): string | null {
-	const modelPath = path
-		.get('properties')
-		.filter((p: NodePath) => bt.isObjectProperty(p.node) && getMemberFilter('model')(p))
-
-	if (!modelPath.length) {
-		return null
-	}
-
-	const modelPropertyNamePath =
-		modelPath.length &&
-		modelPath[0]
-			.get('value')
-			.get('properties')
-			.filter((p: NodePath) => bt.isObjectProperty(p.node) && getMemberFilter('prop')(p))
-
-	if (!modelPropertyNamePath.length) {
-		return null
-	}
-
-	const valuePath = modelPropertyNamePath[0].get('value')
-
-	return bt.isStringLiteral(valuePath.node) ? valuePath.node.value : null
 }

--- a/packages/vue-docgen-api/tests/components/button/__snapshots__/button.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/button/__snapshots__/button.test.ts.snap
@@ -48,25 +48,6 @@ Object {
   "methods": undefined,
   "props": Array [
     Object {
-      "defaultValue": Object {
-        "func": false,
-        "value": "'example model'",
-      },
-      "description": "Model example2",
-      "name": "v-model",
-      "tags": Object {
-        "model": Array [
-          Object {
-            "description": true,
-            "title": "model",
-          },
-        ],
-      },
-      "type": Object {
-        "name": "string",
-      },
-    },
-    Object {
       "description": "Sm breakpoint and above",
       "name": "spanSm",
       "type": Object {
@@ -233,6 +214,25 @@ a factory function",
       "name": "example3",
       "type": Object {
         "name": "number",
+      },
+    },
+    Object {
+      "defaultValue": Object {
+        "func": false,
+        "value": "'example model'",
+      },
+      "description": "Model example2",
+      "name": "example2",
+      "tags": Object {
+        "model": Array [
+          Object {
+            "description": true,
+            "title": "model",
+          },
+        ],
+      },
+      "type": Object {
+        "name": "string",
       },
     },
     Object {

--- a/packages/vue-docgen-api/tests/components/button/button.test.ts
+++ b/packages/vue-docgen-api/tests/components/button/button.test.ts
@@ -170,18 +170,18 @@ describe('tests button', () => {
 			expect(getTestDescriptor(docButton.props, 'example').description).toBe('The example props')
 		})
 
-		it('should v-model to be string', () => {
-			expect(getTestDescriptor(docButton.props, 'v-model').type).toEqual({ name: 'string' })
+		it('should example2 to be string', () => {
+			expect(getTestDescriptor(docButton.props, 'example2').type).toEqual({ name: 'string' })
 		})
 
-		it('should value default v-model to be example model', () => {
-			expect(getTestDescriptor(docButton.props, 'v-model').defaultValue).toMatchObject({
+		it('should value default example2 to be example model', () => {
+			expect(getTestDescriptor(docButton.props, 'example2').defaultValue).toMatchObject({
 				value: `'example model'`
 			})
 		})
 
-		it('should value default v-model props description to be Model example2', () => {
-			expect(getTestDescriptor(docButton.props, 'v-model').description).toBe('Model example2')
+		it('should value default example2 props description to be Model example2', () => {
+			expect(getTestDescriptor(docButton.props, 'example2').description).toBe('Model example2')
 		})
 
 		it('should propE to be string', () => {

--- a/packages/vue-docgen-api/tests/components/checkbox/Checkbox.vue
+++ b/packages/vue-docgen-api/tests/components/checkbox/Checkbox.vue
@@ -1,0 +1,17 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+export default {
+  model: {
+    prop: 'checked',
+    event: 'checked:update'
+  },
+  props: {
+    checked: {
+      type: Boolean
+    }
+  }
+};
+</script>

--- a/packages/vue-docgen-api/tests/components/checkbox/checkbox.test.ts
+++ b/packages/vue-docgen-api/tests/components/checkbox/checkbox.test.ts
@@ -1,0 +1,18 @@
+import * as path from 'path'
+import { ComponentDoc } from '../../../src/Documentation'
+import { parse } from '../../../src/main'
+
+const checkbox = path.join(__dirname, './Checkbox.vue')
+let docCheckbox: ComponentDoc
+
+describe('tests checkbox', () => {
+	beforeEach(async () => {
+		docCheckbox = await parse(checkbox)
+	})
+
+	it('should extract props from template', () => {
+		expect(docCheckbox.props).toContainEqual(
+			expect.objectContaining({ name: 'checked', type: { name: 'boolean' } })
+		)
+	})
+})

--- a/packages/vue-docgen-api/tests/components/functional/InputWrapper-functional.test.ts
+++ b/packages/vue-docgen-api/tests/components/functional/InputWrapper-functional.test.ts
@@ -8,6 +8,8 @@ let docButton: ComponentDoc
 describe('tests button functional', () => {
 	beforeEach(async () => {
 		docButton = await parse(button)
+		// make sure all props are always in the same order
+		docButton.props = docButton.props?.sort((p1, p2) => (p1.name < p2.name ? 1 : -1))
 	})
 
 	it('should extract props from template if functional', () => {
@@ -15,15 +17,11 @@ describe('tests button functional', () => {
 			expect.objectContaining({ name: 'error', type: { name: 'boolean' } })
 		)
 		expect(docButton.props).toContainEqual(
-			expect.objectContaining({ name: 'v-model', type: { name: 'string' } })
+			expect.objectContaining({ name: 'value', type: { name: 'string' } })
 		)
 		expect(docButton.props).toContainEqual(
 			expect.objectContaining({ name: 'label', type: { name: 'string' } })
 		)
-	})
-
-	it('should not return the value props as it is v-model', () => {
-		expect(docButton.props).not.toMatchObject([{ name: 'value', type: { name: 'string' } }])
 	})
 
 	it('should match the snapshot', () => {

--- a/packages/vue-docgen-api/tests/components/functional/__snapshots__/InputWrapper-functional.test.ts.snap
+++ b/packages/vue-docgen-api/tests/components/functional/__snapshots__/InputWrapper-functional.test.ts.snap
@@ -17,14 +17,26 @@ Object {
   "methods": undefined,
   "props": Array [
     Object {
-      "defaultValue": Object {
-        "func": false,
-        "value": "false",
+      "description": "Input value",
+      "name": "value",
+      "required": true,
+      "tags": Object {
+        "model": Array [
+          Object {
+            "description": true,
+            "title": "model",
+          },
+        ],
       },
-      "description": "Should display error?",
-      "name": "error",
       "type": Object {
-        "name": "boolean",
+        "name": "string",
+      },
+    },
+    Object {
+      "description": "Prefix string for input field",
+      "name": "prefix",
+      "type": Object {
+        "name": "string",
       },
     },
     Object {
@@ -32,10 +44,26 @@ Object {
         "func": false,
         "value": "false",
       },
-      "description": "Should the input be focused?",
-      "name": "focused",
+      "description": "True if input label should always be \\"up there\\"",
+      "name": "labelAlwaysFloating",
       "type": Object {
         "name": "boolean",
+      },
+    },
+    Object {
+      "description": "String for label text",
+      "name": "label",
+      "required": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    Object {
+      "description": "Input ID",
+      "name": "id",
+      "required": true,
+      "type": Object {
+        "name": "string|number",
       },
     },
     Object {
@@ -54,50 +82,10 @@ Object {
         "func": false,
         "value": "false",
       },
-      "description": "Should the input be disabled?",
-      "name": "disabled",
+      "description": "Should the input be focused?",
+      "name": "focused",
       "type": Object {
         "name": "boolean",
-      },
-    },
-    Object {
-      "name": "value",
-      "type": Object {
-        "name": "undefined",
-      },
-    },
-    Object {
-      "defaultValue": Object {
-        "func": false,
-        "value": "false",
-      },
-      "description": "True if input label should always be \\"up there\\"",
-      "name": "labelAlwaysFloating",
-      "type": Object {
-        "name": "boolean",
-      },
-    },
-    Object {
-      "description": "Prefix string for input field",
-      "name": "prefix",
-      "type": Object {
-        "name": "string",
-      },
-    },
-    Object {
-      "description": "Input ID",
-      "name": "id",
-      "required": true,
-      "type": Object {
-        "name": "string|number",
-      },
-    },
-    Object {
-      "description": "String for label text",
-      "name": "label",
-      "required": true,
-      "type": Object {
-        "name": "string",
       },
     },
     Object {
@@ -112,19 +100,25 @@ Object {
       },
     },
     Object {
-      "description": "Input value",
-      "name": "v-model",
-      "required": true,
-      "tags": Object {
-        "model": Array [
-          Object {
-            "description": true,
-            "title": "model",
-          },
-        ],
+      "defaultValue": Object {
+        "func": false,
+        "value": "false",
       },
+      "description": "Should display error?",
+      "name": "error",
       "type": Object {
-        "name": "string",
+        "name": "boolean",
+      },
+    },
+    Object {
+      "defaultValue": Object {
+        "func": false,
+        "value": "false",
+      },
+      "description": "Should the input be disabled?",
+      "name": "disabled",
+      "type": Object {
+        "name": "boolean",
       },
     },
   ],

--- a/packages/vue-docgen-api/tests/components/jsfile/button-js.test.ts
+++ b/packages/vue-docgen-api/tests/components/jsfile/button-js.test.ts
@@ -26,7 +26,7 @@ describe('tests button with pure javascript', () => {
 		Array [
 		  "color",
 		  "id",
-		  "v-model",
+		  "inputValue",
 		  "falseValue",
 		  "trueValue",
 		  "multiple",

--- a/packages/vue-docgen-api/tests/components/multiple-exports/multiple-exports.test.ts
+++ b/packages/vue-docgen-api/tests/components/multiple-exports/multiple-exports.test.ts
@@ -31,7 +31,7 @@ describe('tests components with multiple exports', () => {
 		Array [
 		  "color",
 		  "id",
-		  "v-model",
+		  "inputValue",
 		  "falseValue",
 		  "trueValue",
 		  "multiple",


### PR DESCRIPTION
## What?

This PR will change the behavior of `propHandler` to return `propertyName` instead of string `v-model` in case of model prop.

https://github.com/vue-styleguidist/vue-styleguidist/blob/70cbb593cbbb6f94f300c5c1ddad69c4d38e81e7/packages/vue-docgen-api/src/script-handlers/propHandler.ts#L80-L82

Fix #1039

## Why?

I ran into a problem when using the storybook with vue which uses this package to automatically generate [ArgTypes](https://storybook.js.org/docs/vue/api/argtypes#automatic-argtype-inference).

My checkbox component

```html
<script>
  export default {
    model: {
      prop: 'checked',
      event: 'change'
    },

    props: {
      label: String,
      checked: Boolean
    }
  }
</script>
```

and the output is 

```javascript
{
  v-model: { name: 'v-model', type: { name: 'boolean' }, ... },
  label: { name: 'label', type: { name: 'string' }, ... }
}
```

and then bind it to component

```javascript
const Template = (args, { argTypes }) => ({
  components: { Checkbox },
  props: Object.keys(argTypes),
  template: '<Checkbox v-bind="$props" />'
})
```

As you can see, the storybook assumes that the output from this api will return the prop name like `label` but in the case of model prop this api return `v-model` which is not an actual prop but it is a directive.

So I think we should return the real prop name instead of string `v-model` and use different field to indicate that this prop is a model prop.

As in this comment https://github.com/vue-styleguidist/vue-styleguidist/issues/1039#issuecomment-757972226.

## How?

For now I only change the code to return `propertyName` whether that prop is model prop or not. Since I'm really new here, I'm not sure what fields to use to specify this is a prop model, or even if I should include it in this PR.

And this looks like a breaking change, not sure if it's possible. I would like to hear your feedback.

This is my first time here, sorry for the mistake. Thank you for your time.