### PR TITLE
doc: typo in "Documenting components" docs page

### DIFF
--- a/docs/docs/Documenting.md
+++ b/docs/docs/Documenting.md
@@ -231,7 +231,7 @@ The comment block containing the documentation needs to contain one line with `@
 ```html
 <div>
   <!--
-    trigered on click
+    triggered on click
     @event click
     @property {object} demo - example
     @property {number} called - test called


### PR DESCRIPTION
Fixed minor typo in docs on page "Documenting components"