### PR TITLE
fix: make usage table font sizes and spacing consistent

### DIFF
--- a/packages/vue-styleguidist/src/client/rsg-components/Methods/MethodsRenderer.tsx
+++ b/packages/vue-styleguidist/src/client/rsg-components/Methods/MethodsRenderer.tsx
@@ -18,24 +18,30 @@ function renderMethodName({ name, tags = {} }: MethodDescriptor) {
 	return <Name deprecated={!!tags.deprecated}>{`${name}()`}</Name>
 }
 
-function renderDescription({ description, returns, tags = {} }: MethodDescriptor) {
-	return (
-		<>
-			{description && <Markdown text={description} />}
-			{returns && (
-				<div>
-					Returns:{' '}
-					<Argument
-						name=""
-						{...returns}
-						type={returns.type ? { name: renderTypeString(returns.type) } : undefined}
-						description={returns.description as string}
-					/>
-				</div>
-			)}
-			<JsDoc {...tags} />
-		</>
-	)
+function renderDescription(myClasses: Record<string, string>) {
+	return function renderDesc({ description, returns, tags = {} }: MethodDescriptor) {
+		return (
+			<>
+				{description && (
+					<div className={myClasses.descriptionWrapper}>
+						<Markdown text={description} />
+					</div>
+				)}
+				{returns && (
+					<div>
+						Returns:{' '}
+						<Argument
+							name=""
+							{...returns}
+							type={returns.type ? { name: renderTypeString(returns.type) } : undefined}
+							description={returns.description as string}
+						/>
+					</div>
+				)}
+				<JsDoc {...tags} />
+			</>
+		)
+	}
 }
 
 function renderParameters({ params = [] }: MethodDescriptor) {
@@ -60,7 +66,7 @@ export const columns = (methods: MethodDescriptor[], classes: Record<string, str
 	},
 	{
 		caption: 'Description',
-		render: renderDescription,
+		render: renderDescription(classes),
 		className: classes.description
 	},
 	{

--- a/packages/vue-styleguidist/src/client/rsg-components/Methods/__tests__/__snapshots__/MethodsRenderer.tsx.snap
+++ b/packages/vue-styleguidist/src/client/rsg-components/Methods/__tests__/__snapshots__/MethodsRenderer.tsx.snap
@@ -79,11 +79,15 @@ exports[`MethodsRenderer should render a table 1`] = `
         <td
           class="rsg--cell-12 rsg--description-3"
         >
-          <p
-            class="rsg--para-15"
+          <div
+            class="rsg--descriptionWrapper-2"
           >
-            Public
-          </p>
+            <p
+              class="rsg--para-15"
+            >
+              Public
+            </p>
+          </div>
         </td>
         <td
           class="rsg--cell-12"
@@ -149,11 +153,13 @@ exports[`MethodsRenderer should render parameters 1`] = `
         </code>
       </div>
       <div>
-        <p
-          class="rsg--para-15"
-        >
-          Public
-        </p>
+        <div>
+          <p
+            class="rsg--para-15"
+          >
+            Public
+          </p>
+        </div>
       </div>
       <div>
         <div
@@ -204,11 +210,13 @@ exports[`MethodsRenderer should render public method 1`] = `
         </code>
       </div>
       <div>
-        <p
-          class="rsg--para-15"
-        >
-          Public
-        </p>
+        <div>
+          <p
+            class="rsg--para-15"
+          >
+            Public
+          </p>
+        </div>
       </div>
       <div />
     </li>

--- a/packages/vue-styleguidist/src/client/rsg-components/Props/PropsRenderer.js
+++ b/packages/vue-styleguidist/src/client/rsg-components/Props/PropsRenderer.js
@@ -22,9 +22,11 @@ function renderDescription(classes) {
 
 		return (
 			<div>
-				<div className={classes.descriptionWrapper}>
-					{description && <Markdown text={description} />}
-				</div>
+				{description && (
+					<div className={classes.descriptionWrapper}>
+						<Markdown text={description} />
+					</div>
+				)}
 				<JsDoc {...tags} />
 				{args.length > 0 && <Arguments args={args} heading />}
 				{returnDocumentation && <Argument {...returnDocumentation} returns />}

--- a/packages/vue-styleguidist/src/client/rsg-components/SlotsTable/SlotsTableRenderer.js
+++ b/packages/vue-styleguidist/src/client/rsg-components/SlotsTable/SlotsTableRenderer.js
@@ -10,9 +10,15 @@ import Arguments from 'rsg-components/Arguments'
 import getOriginColumn from 'rsg-components/OriginColumn'
 import propStyles from '../../utils/propStyles'
 
-function renderDescription(prop) {
-	const { description } = prop
-	return <div>{description ? <Markdown text={description} /> : '-'}</div>
+function renderDescription(myClasses) {
+	return function renderDesc(prop) {
+		const { description } = prop
+		return (
+			<div className={myClasses.descriptionWrapper}>
+				{description ? <Markdown text={description} /> : '-'}
+			</div>
+		)
+	}
 }
 
 function renderName(prop) {
@@ -44,7 +50,7 @@ export const columns = (slots, classes) => [
 	},
 	{
 		caption: 'Description',
-		render: renderDescription,
+		render: renderDescription(classes),
 		className: classes.description
 	},
 	// only add the bindings column if there is any bindings

--- a/packages/vue-styleguidist/src/client/utils/propStyles.ts
+++ b/packages/vue-styleguidist/src/client/utils/propStyles.ts
@@ -10,14 +10,21 @@ const methodStyles = ({ space }: Rsg.Theme) => ({
 	},
 	type: {
 		isolate: false,
-		margin: [[space[1], 0, 0, space[1]]],
-		opacity: 0.5
+		marginLeft: space[1],
+		opacity: 0.5,
+		'& pre': {
+			margin: 0
+		}
 	},
 	descriptionWrapper: {
 		// remove bottom margin from description
 		'& p': {
 			margin: 0,
 			minWidth: 350
+		},
+		// add space before any next sibling
+		'& + *': {
+			marginTop: space[1]
 		}
 	},
 	description: {


### PR DESCRIPTION

- Apply to slots and methods the same `descriptionWrapper` class that is applied to props and events.
- Remove vertical spacing of prop types when no prop description is provided.

## Before

![image](https://user-images.githubusercontent.com/115310/117125727-d3310380-ad91-11eb-881c-5e562355bcdf.png)

## After

![image](https://user-images.githubusercontent.com/115310/117126108-3a4eb800-ad92-11eb-9a8d-fcb8f4816e96.png)

## Before

![image](https://user-images.githubusercontent.com/115310/117125782-e512a680-ad91-11eb-8de3-bc061b0eedd9.png)

## After 

![image](https://user-images.githubusercontent.com/115310/117125898-083d5600-ad92-11eb-918a-bc09496a24aa.png)
