### PR TITLE
docs: fix syntax highlighting at "Writing code examples" section

### DIFF
--- a/docs/docs/Documenting.md
+++ b/docs/docs/Documenting.md
@@ -771,14 +771,12 @@ const mockData = require('./mocks');
 
 > **Note:** If you need a more complex demo it’s often a good idea to define it in a separate JavaScript file and `import` it in Markdown. If the component file is in the same folder as the markdown, write `import { myExample as exam } from './myExample';` You can then use this imported setup object in your examples. Note that the code for the setup will not appear in the documentation.
 >
-> ````md
-> ```js
-> import { myExample as Button } from './myExample'
-> ;<div>
+> ```jsx
+> import { myExample as Button } from './myExample';
+> <div>
 >   <Button />
 > </div>
 > ```
-> ````
 
 > **Note** If you prefer to use JSX in your examples, use the [jsxInExample](/Configuration.md#jsxInExamples) option in your `styleguide.config.js`. Using this option will force you to use proper Vue format for your examples. No more pseudo-JSX code.
 >


### PR DESCRIPTION
Noticed that on this [docs page](https://vue-styleguidist.github.io/docs/Documenting.html#writing-code-examples), the style of the note is broken.

![image](https://user-images.githubusercontent.com/42717522/121361371-9b2a5c80-c90b-11eb-9d61-771a597ab0c8.png)
