### PR TITLE
fix(cli): expected corresponding JSX closing tag for <br>

### DIFF
--- a/packages/vue-docgen-cli/src/templates/utils.ts
+++ b/packages/vue-docgen-cli/src/templates/utils.ts
@@ -7,7 +7,7 @@ import memoize from 'lodash.memoize'
  * @param input
  */
 export function mdclean(input: string): string {
-	return input.replace(/\r?\n/g, '<br>').replace(/\|/g, '\\|')
+	return input.replace(/\r?\n/g, '<br/>').replace(/\|/g, '\\|')
 }
 
 const readdirSync = memoize(fs.readdirSync)


### PR DESCRIPTION
When there is a multiline description in a prop a line break tag (`<br>`) is being added. `mdx-loader` expects tag to be closed. Otherwise, it throws "`SyntaxError: unknown: Expected corresponding JSX closing tag for <br>`" error.

```
ERROR in ./src/components/modal/README.md
Module build failed (from ./node_modules/mdx-loader/index.js):
SyntaxError: unknown: Expected corresponding JSX closing tag for <br>. (94:144)

  92 | <tr parentName="tbody">
  93 | <td parentName="tr" {...{"align":null}}>{`keepMounted`}</td>
> 94 | <td parentName="tr" {...{"align":null}}>{`Keeps the modal rendered when it’s not active.`}<br>{`This is useful when the modal content is heavy`}</td>
     |                                                                                                                                                 ^
```