### PR TITLE
feat(utils): add the ability to remove the added scoped style

### DIFF
--- a/packages/vue-inbrowser-compiler-utils/src/addScopedStyle.ts
+++ b/packages/vue-inbrowser-compiler-utils/src/addScopedStyle.ts
@@ -1,15 +1,18 @@
 import scoper from './styleScoper'
 
+const noop = () => {}
+
 /**
  * Adds a style block to the head to load the styles.
  * uses the suffix to scope the styles
  * @param {string} css css code to add the the head
  * @param {string} suffix string to add to each selector as a scoped style to avoid conflicts
+ * @returns a function that discard the added style element (if there is one)
  */
-export default function addScopedStyle(css: string, suffix: string) {
+export default function addScopedStyle(css: string, suffix: string): () => void {
 	// protect server side rendering
 	if (typeof document === 'undefined') {
-		return
+		return noop
 	}
 	const head = document.head || document.getElementsByTagName('head')[0]
 	const newstyle = document.createElement('style')
@@ -22,4 +25,8 @@ export default function addScopedStyle(css: string, suffix: string) {
 		newstyle.appendChild(document.createTextNode(csses))
 	}
 	head.appendChild(newstyle)
+
+	return () => {
+		head.removeChild(newstyle)
+	}
 }


### PR DESCRIPTION
There was no way to discard a formerly added scoped style, which leads to new `<style>` tags piling up in scenarios like `vue-live`.

This commit added a discard function as the return value of `addScopedStyle` so we can remove it when needed.

---

It seems that we don't have tests for `addScopedStyle` now so I didn't add tests for it. The update is pretty simple.