### PR TITLE
feat(utils): add selector combinators support for styleScoper

### DIFF
--- a/packages/vue-inbrowser-compiler-utils/src/__tests__/styleScoper.ts
+++ b/packages/vue-inbrowser-compiler-utils/src/__tests__/styleScoper.ts
@@ -7,8 +7,8 @@ describe('styleScoper', () => {
 	})
 
 	it('should scope css pseudo selectors', () => {
-		const scopedCSS = scoper(`.bonjour:before{color:blue;}`, '[test]')
-		expect(scopedCSS).toBe('.bonjour[test]:before {color:blue;}')
+		const scopedCSS = scoper(`.bonjour:before, .hello:hover::after{color:blue;}`, '[test]')
+		expect(scopedCSS).toBe('.bonjour[test]:before ,.hello[test]:hover:after {color:blue;}')
 	})
 
 	it('should scope multiple css selectors', () => {
@@ -27,7 +27,12 @@ describe('styleScoper', () => {
 			'[test]'
 		)
 		expect(scopedCSS).toBe(
-			'.bonjour[test] .hello[test]  .deepClass,.salut[test] .goodbye[test]  .deepClass{color:blue;}'
+			'.bonjour[test] .hello[test] .deepClass,.salut[test] .goodbye[test] .deepClass{color:blue;}'
 		)
+	})
+
+	it('should scope css with selector combinators', () => {
+		const scopedCSS = scoper(`.bonjour > .hello + .salut ~ .goodbye {color:blue;}`, '[test]')
+		expect(scopedCSS).toBe('.bonjour[test] > .hello[test] + .salut[test] ~ .goodbye[test] {color:blue;}')
 	})
 })

--- a/packages/vue-inbrowser-compiler-utils/src/styleScoper.ts
+++ b/packages/vue-inbrowser-compiler-utils/src/styleScoper.ts
@@ -5,7 +5,7 @@ export default function scoper(css: string, suffix: string) {
 	const re = /([^\r\n,{}]+)(,(?=[^}]*{)|s*{)/g
 
 	// `after` is going to contain eithe a comma or an opening curly bracket
-	css = css.replace(re, function (full, selector, after) {
+	css = css.replace(re, function (full: string, selector: string, after: string) {
 		// if non-rule delimiter
 		if (selector.match(/^\s*(@media|@keyframes|to|from|@font-face)/)) {
 			return selector + after
@@ -16,7 +16,7 @@ export default function scoper(css: string, suffix: string) {
 		if (arrayDeep) {
 			const [, beforeVDeep, , afterVDeep] = arrayDeep
 			selector = beforeVDeep
-			after = afterVDeep + after
+			after = (afterVDeep + after).trim()
 		}
 
 		// deal with :scope pseudo selectors
@@ -29,18 +29,19 @@ export default function scoper(css: string, suffix: string) {
 			})
 		}
 
-		// deal with other pseudo selectors
-		let pseudo = ''
-		if (selector && selector.match(/:/)) {
-			const parts = selector.split(/:/)
-			selector = parts[0]
-			pseudo = ':' + parts[1]
-		}
+		selector = selector.split(/\s+/).filter(part => !!part).map(part => {
+			// combinators
+			if (/^[>~+]$/.test(part)) {
+				return part
+			}
 
-		selector = selector.trim() + ' '
-		selector = selector.replace(/ /g, suffix + pseudo + ' ')
+			// deal with other pseudo selectors
+			const [main, ...rest] = part.split(/:{1,2}/)
+			let pseudo = rest.map(piece => `:${piece}`).join('')
+			return main + suffix + pseudo
+		}).join(' ')
 
-		return selector + after
+		return selector + ' ' + after
 	})
 
 	return css


### PR DESCRIPTION
Existing implementation doesn't work for selectors with combinators like `>`, `~` and `+`.

This PR add support for that.