### PR TITLE
fix: should escape interpolation inside template string

### DIFF
--- a/packages/vue-inbrowser-compiler/src/__tests__/compileVueCodeForEvalFunction.ts
+++ b/packages/vue-inbrowser-compiler/src/__tests__/compileVueCodeForEvalFunction.ts
@@ -43,7 +43,7 @@ new Vue({
 		const Vue = require('vue').default;
 		const MyButton = require('./MyButton.vue').default;
 		Vue.component('MyButton', MyButton);
-		
+
 		let param = 'BazFoo';
 		<div>
 			<MyButton> {{param}} </MyButton>
@@ -164,5 +164,22 @@ new Vue({
 				};
 				"
 	`)
+	})
+
+	it('should escape template correctly', () => {
+		let sut = compileVueCodeForEvalFunction(`
+<template>
+	<div>{{ \`\${value}\` }}</div>
+</template>
+<script>
+export default {
+	data () {
+		return {
+			value: 1
+		}
+	}
+}
+</script>`)
+		expect(() => new Function(sut.script)()).not.toThrow()
 	})
 })

--- a/packages/vue-inbrowser-compiler/src/normalizeSfcComponent.ts
+++ b/packages/vue-inbrowser-compiler/src/normalizeSfcComponent.ts
@@ -26,14 +26,14 @@ function getSingleFileComponentParts(code: string) {
 	return parts
 }
 
-function injectTemplateAndParseExport(
-	parts: VsgSFCDescriptor
-): {
+function injectTemplateAndParseExport(parts: VsgSFCDescriptor): {
 	preprocessing?: string
 	component: string
 	postprocessing?: string
 } {
-	const templateString = parts.template ? parts.template.replace(/`/g, '\\`') : undefined
+	const templateString = parts.template
+		? parts.template.replace(/`/g, '\\`').replace(/\$\{/g, '\\${')
+		: undefined
 
 	if (!parts.script) {
 		return { component: `{template: \`${templateString}\` }` }
@@ -48,9 +48,7 @@ function injectTemplateAndParseExport(
 	return comp
 }
 
-export function parseScriptCode(
-	code: string
-): {
+export function parseScriptCode(code: string): {
 	preprocessing?: string
 	component: string
 	postprocessing?: string


### PR DESCRIPTION
Currently interpolation inside template string isn't properly escaped so that identifiers will leak to outer scope, causing '<var>identifier</var> is not defined' errors.