### PR TITLE
fix: parse imported TS correctly if SFC is JS

### DIFF
--- a/packages/vue-docgen-api/src/utils/getPathFromExportedValue.ts
+++ b/packages/vue-docgen-api/src/utils/getPathFromExportedValue.ts
@@ -11,8 +11,6 @@ import { ParseOptions } from '../parse'
 
 const read = promisify(readFile)
 
-const tsExtensions = /.tsx?$/
-
 export default async function getPathOfExportedValue(
 	pathResolver: (path: string, originalDirNameOverride?: string) => string | null,
 	exportName: string,
@@ -32,8 +30,8 @@ export default async function getPathOfExportedValue(
 		}
 
 		let filePlugins = plugins
-        // Fixes SFCs written in JS having their imported modules being assumed to also be JS
-		if (tsExtensions.test(currentFilePath)) {
+		// Fixes SFCs written in JS having their imported modules being assumed to also be JS
+		if (/.tsx?$/.test(currentFilePath)) {
 			filePlugins = filePlugins.map(plugin => plugin === 'flow' ? 'typescript' : plugin)
 		}
 


### PR DESCRIPTION
We noticed this over in [WordPress/openverse-frontend](https://github.com/WordPress/openverse-frontend/runs/5432695832?check_suite_focus=true) in [this pr](https://github.com/WordPress/openverse-frontend/pull/1058) under [this Storybook CI run](https://github.com/WordPress/openverse-frontend/runs/5432695832?check_suite_focus=true). After some local debugging trying to figure out why the incorrect parser was being used for the imported TypeScript module, I found the cause.

Essentially there was an implicit assumption (I believe this was an oversight, not intentional assumption) that if the file that was importing a module was written in JavaScript, that the imported modules would also by plain JS (or at most flow).

Because flow and TS overlap in some of their syntax, this hid the error from our team for a while because we just happened to be converting files that were 1:1 syntactically between a flow and TS version of those files. The babel flow plugin was doing fine parsing those files. However, when we added a cast, it finally surfaced. Flow and TS have completely different casting syntaxes so the flow babel plugin though there was a missing semicolon.

This PR updates the variable resolution code to check the path of the file that is about to be parsed and to use the TypeScript plugin instead of flow when the extension of the module is `ts` or `tsx`. I've tried this out locally by modifying `vue-docgen-api` in my node_modules and it appears to work perfectly.

I wanted to add some unit tests for this in the `parseValidator` tests but there weren't any existing tests for imports so I wasn't sure exactly how to structure any additional tests. Any guidance there would be appreciated.