### PR TITLE
docs: Added missing comma to allow editLinkLable to be included in the config

### DIFF
--- a/packages/vue-docgen-cli/README.md
+++ b/packages/vue-docgen-cli/README.md
@@ -79,7 +79,7 @@ module.exports = {
   },
   docsRepo: 'profile/repo',
   docsBranch: 'master',
-  docsFolder: ''
+  docsFolder: '',
   editLinkLabel: 'Edit on github'
 }
 ```


### PR DESCRIPTION
Issue: There is a missing comma in the documentation for Config File that excludes `` editLinkLabel: 'Edit on github'`` from being an accessible option when copied from the readme and added to a project. 

Solution: I added the comma to the README.md file.