### PR TITLE
fix: 🐛 webpack5 serve undefined process

### DIFF
--- a/packages/vue-styleguidist/package.json
+++ b/packages/vue-styleguidist/package.json
@@ -63,6 +63,7 @@
     "mini-html-webpack-plugin": "^3.1.3",
     "minimist": "^1.2.5",
     "prismjs": "^1.23.0",
+    "process": "^0.11.10",
     "prop-types": "^15.7.2",
     "q-i": "2.0.1",
     "qss": "^2.0.3",

--- a/packages/vue-styleguidist/src/scripts/make-webpack-config.ts
+++ b/packages/vue-styleguidist/src/scripts/make-webpack-config.ts
@@ -166,7 +166,14 @@ export default function (
 					// `webpackHotDevClient`.
 					injectClient: false
 				},
-				plugins: [new webpack.HotModuleReplacementPlugin()],
+				plugins: [
+					new webpack.HotModuleReplacementPlugin(),
+					new webpack.ProvidePlugin({
+						// Webpack 5 does no longer include a polyfill for this Node.js variable.
+						// https://webpack.js.org/migrate/5/#run-a-single-build-and-follow-advice
+						process: 'process/browser'
+					})
+				],
 				entry: [require.resolve('react-dev-utils/webpackHotDevClient')]
 			},
 			webpackConfig


### PR DESCRIPTION
Webpack 5 does no longer include a polyfill for this Node.js variable.
We need to define them manually.
https://webpack.js.org/migrate/5/#run-a-single-build-and-follow-advice

✅ Closes: #1074

Signed-off-by: John Molakvoæ <skjnldsv@protonmail.com>