### PR TITLE
fix(vue-docgen-api): make doc defineExpose  working

### DIFF
--- a/.changeset/gorgeous-rivers-tie.md
+++ b/.changeset/gorgeous-rivers-tie.md
@@ -1,0 +1,6 @@
+---
+"vue-docgen-api": patch
+---
+
+- fix `defineExposed` into `defineExpose`
+- add the exposed member to the documentation

--- a/packages/vue-docgen-api/src/Documentation.ts
+++ b/packages/vue-docgen-api/src/Documentation.ts
@@ -112,6 +112,7 @@ export default class Documentation {
 		const methods = this.getObjectFromDescriptor(this.methodsMap)
 		const events = this.getObjectFromDescriptor(this.eventsMap)
 		const slots = this.getObjectFromDescriptor(this.slotsMap)
+		const exposes = this.getObjectFromDescriptor(this.exposedMap)
 
 		const obj: { [key: string]: any } = {}
 		this.dataMap.forEach((value, key) => {
@@ -133,6 +134,7 @@ export default class Documentation {
 			// set all the static properties
 			exportName: obj.exportName,
 			displayName: obj.displayName,
+			exposes,
 			props,
 			events,
 			methods,

--- a/packages/vue-docgen-api/src/script-setup-handlers/setupExposedHandler.test.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/setupExposedHandler.test.ts
@@ -43,7 +43,7 @@ describe('setupExposedHandler', () => {
 	it('should resolve Exposed in setup script', async () => {
 		const src = `
         const testProps = 0
-        defineExposed({ testProps })
+        defineExpose({ testProps })
         `
 		await parserTest(src)
 		expect(documentation.getExposedDescriptor).toHaveBeenCalledWith('testProps')
@@ -52,7 +52,7 @@ describe('setupExposedHandler', () => {
 	it('should resolve Exposed descriptions in setup script', async () => {
 		const src = `
         const testPropsInner = 0
-        defineExposed({
+        defineExpose({
           /**
            * Exposed test props
            */
@@ -71,7 +71,7 @@ describe('setupExposedHandler', () => {
 	it('should resolve Exposed items pushed by strings', async () => {
 		const src = `
         const testPropsInner = 0
-        defineExposed({
+        defineExpose({
           /**
            * Exposed test props
            */

--- a/packages/vue-docgen-api/src/script-setup-handlers/setupExposedHandler.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/setupExposedHandler.ts
@@ -39,7 +39,7 @@ export default async function setupExposedHandler(
 
 	visit(astPath.program, {
 		visitCallExpression(nodePath) {
-			if (bt.isIdentifier(nodePath.node.callee) && nodePath.node.callee.name === 'defineExposed') {
+			if (bt.isIdentifier(nodePath.node.callee) && nodePath.node.callee.name === 'defineExpose') {
 				if (bt.isObjectExpression(nodePath.get('arguments', 0).node)) {
 					nodePath.get('arguments', 0, 'properties').each((prop: NodePath<bt.ObjectProperty>) => {
 						if (bt.isIdentifier(prop.node.key)) {


### PR DESCRIPTION
In Vue3, expose properties by using `defineExpose()` API, not `defineExposed()`, and an `exposes` meta should be in the results.

```html
<script setup lang="ts">
function foo() { return 'bar' }
defineExpose({
  /**
   * Expose foo function
   *
   * @returns {string} The result of execute foo
   */
  foo,
})
</script>
```

output:
```js
{
  // ...
  exposes: [{
    description: 'Expose foo function',
    name: 'foo',
    tags: [ ... ],
  }],
}
```