### PR TITLE
feat: silence webpack5

### DIFF
--- a/.changeset/bright-pillows-work.md
+++ b/.changeset/bright-pillows-work.md
@@ -1,0 +1,5 @@
+---
+'vue-styleguidist': patch
+---
+
+Avoid having a long webpack log at successful build

--- a/packages/vue-styleguidist/src/scripts/create-server.ts
+++ b/packages/vue-styleguidist/src/scripts/create-server.ts
@@ -23,7 +23,7 @@ export default function createServer(
 					ignored: /node_modules/
 				},
 				watchContentBase: config.assetsDir !== undefined,
-				stats: webpackConfig.stats || {}
+				stats: webpackConfig.stats || false
 			}
 		},
 		{


### PR DESCRIPTION
avoid having the following log on webpack 5

```log
  asset build/main.bundle.js 95.7 KiB [emitted] (name: main)
asset favicon.ico 4.19 KiB [emitted] [from: public/favicon.ico] [copied]
asset index.html 355 bytes [emitted]
Entrypoint main [big] 5.57 MiB = build/chunk-vendors.bundle.js 5.47 MiB build/main.bundle.js 95.7 KiB
runtime modules 31 KiB 16 modules
modules by path ./node_modules/ 5.69 MiB
  cacheable modules 5.67 MiB 1121 modules
  ./node_modules/@vue/compiler-sfc/dist/ sync 160 bytes [built] [code generated]
  ./node_modules/regenerate-unicode-properties/ ./node_modules/regenerate-unicode-properties/ sync ^\.\/.*\.js$ 13.2 KiB [optional] [built] [code generated]
modules by path ./src/components/ 15.7 KiB
  ./src/components/AppButton.vue 938 bytes [built] [code generated]
  ./node_modules/vue-styleguidist/lib/loaders/vuedoc-loader.js!./src/components/AppButton.vue 2.57 KiB [built] [code generated]
  ./src/components/HelloWorld.vue 928 bytes [built] [code generated]
  ./node_modules/vue-styleguidist/lib/loaders/vuedoc-loader.js!./src/components/HelloWorld.vue 381 bytes [built] [code generated]
  ./src/components/AppButton.vue?vue&type=template&id=41d81733 270 bytes [built] [code generated]
  ./src/components/AppButton.vue?vue&type=script&lang=js 392 bytes [built] [code generated]
  ./src/components/AppButton.vue?vue&type=custom&index=0&blockType=docs&lang=md 564 bytes [built] [code generated]
  + 12 modules
./guide/global.requires.js 149 bytes [built] [code generated]
webpack 5.74.0 compiled successfully in 6792 ms
```