### PR TITLE
Dynamic slot name fix

### DIFF
--- a/.changeset/issue-slot-1285.md
+++ b/.changeset/issue-slot-1285.md
@@ -1,0 +1,5 @@
+---
+"vue-docgen-api": patch
+---
+
+fix: Dynamic slot name fix #1285

--- a/packages/vue-docgen-api/src/script-handlers/slotHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/slotHandler.ts
@@ -189,6 +189,13 @@ export function parseSlotDocBlock(str: string, descriptor: SlotDescriptor) {
 		const description = typeof tagContent === 'string' ? tagContent : undefined
 		if (description && (!descriptor.description || !descriptor.description.length)) {
 			descriptor.description = description
+
+			const fixedNameMatch = description.match(/^(\S+) - (.*)$/)
+
+			if (fixedNameMatch) {
+				descriptor.name = fixedNameMatch[1]
+				descriptor.description = fixedNameMatch[2]
+			}
 		}
 		const tags = jsDoc.tags.filter(t => t.title !== 'slot' && t.title !== 'binding')
 		if (tags.length) {

--- a/packages/vue-docgen-api/src/template-handlers/slotHandler.test.ts
+++ b/packages/vue-docgen-api/src/template-handlers/slotHandler.test.ts
@@ -86,6 +86,46 @@ describe('slotHandler', () => {
 		expect(doc.toObject().slots).toMatchObject([{ name: 'first', description: 'first slot found' }])
 	})
 
+	it('should parse dynamic slot names', () => {
+		const ast = parse(
+			[
+				'<!-- @slot first slot found -->',
+				'<slot :name="`dynamicName`">',
+				'  <div>',
+				'    <h1>title of the template</h1>',
+				'  </div>',
+				'</slot>'
+			].join('\n')
+		)
+
+		traverse(ast.children[1], doc, [slotHandler], ast.children, {
+			functional: false
+		})
+		expect(doc.toObject().slots).toMatchObject([
+			{ name: '`dynamicName`', description: 'first slot found' }
+		])
+	})
+
+	it('should parse dynamic slot names but prefer a fixed name', () => {
+		const ast = parse(
+			[
+				'<!-- @slot theFixedName - first slot found -->',
+				'<slot :name="`dynamicName`">',
+				'  <div>',
+				'    <h1>title of the template</h1>',
+				'  </div>',
+				'</slot>'
+			].join('\n')
+		)
+
+		traverse(ast.children[1], doc, [slotHandler], ast.children, {
+			functional: false
+		})
+		expect(doc.toObject().slots).toMatchObject([
+			{ name: 'theFixedName', description: 'first slot found' }
+		])
+	})
+
 	it('should pick up the name of a slot', () => {
 		const ast = parse(
 			[

--- a/packages/vue-docgen-api/src/template-handlers/slotHandler.ts
+++ b/packages/vue-docgen-api/src/template-handlers/slotHandler.ts
@@ -22,8 +22,19 @@ export default function slotHandler(
 ) {
 	if (isBaseElementNode(templateAst) && templateAst.tag === 'slot') {
 		const nameProp = templateAst.props.filter(isAttributeNode).find(b => b.name === 'name')
-		const slotName =
-			nameProp && nameProp.value && nameProp.value.content ? nameProp.value.content : 'default'
+		let slotName = nameProp && nameProp.value ? nameProp.value.content : undefined
+
+		if (!slotName) {
+			const dynExpr = templateAst.props
+				.filter(isDirectiveNode)
+				.find(b => b.name === 'bind' && isSimpleExpressionNode(b.arg) && b.arg.content === 'name')
+
+			if (dynExpr && isSimpleExpressionNode(dynExpr.exp) && dynExpr.exp) {
+				slotName = dynExpr.exp.content
+			} else {
+				slotName = 'default'
+			}
+		}
 
 		const bindings = templateAst.props.filter(
 			// only keep simple binds and static attributes


### PR DESCRIPTION
Either use the name defined in the comment or return the code of the dynamic name property.

This should fix https://github.com/vue-styleguidist/vue-styleguidist/issues/1285