### PR TITLE
fix: scopeId for vue3 single file components in .md examples

### DIFF
--- a/.changeset/vue3-scopeid.md
+++ b/.changeset/vue3-scopeid.md
@@ -1,0 +1,5 @@
+---
+"vue-styleguidist": patch
+---
+
+fix: scopeId for vue3 single file components in .md examples

--- a/packages/vue-styleguidist/src/client/rsg-components/Preview/getCompiledExampleComponent.ts
+++ b/packages/vue-styleguidist/src/client/rsg-components/Preview/getCompiledExampleComponent.ts
@@ -81,7 +81,11 @@ export function getCompiledExampleComponent({
 		extendsComponent = { store: vuex.default }
 	}
 	const moduleId = 'v-' + Math.floor(Math.random() * 1000) + 1
-	previewComponent._scopeId = 'data-' + moduleId
+	if (isVue3) {
+		previewComponent.__scopeId = 'data-' + moduleId
+	} else {
+		previewComponent._scopeId = 'data-' + moduleId
+	}
 
 	// if we are in local component registration, register current component
 	// NOTA: on independent md files, component.module is undefined


### PR DESCRIPTION
When using Vue3 SFC in markdown examples `scopeId` is not applied.