### PR TITLE
docs: #1482 -  explains how to avoid error when using vue-cli

### DIFF
--- a/docs/docs/GettingStarted.md
+++ b/docs/docs/GettingStarted.md
@@ -55,6 +55,7 @@ For Vue-CLI 3 use this instead:
 }
 ```
 
+> NOTE: If you use the command `vue add styleguidist`, the scripts will be added for you in package.json.
 
 ## 4. Start your style guide
 

--- a/docs/docs/GettingStarted.md
+++ b/docs/docs/GettingStarted.md
@@ -44,6 +44,18 @@ Add these scripts to your `package.json`:
 }
 ```
 
+For Vue-CLI 3 use this instead: 
+
+```diff
+{
+  "scripts": {
++    "styleguide": "vue-cli-service styleguidist",
++    "styleguide:build": "vue-cli-service styleguidist:build"
+  }
+}
+```
+
+
 ## 4. Start your style guide
 
 Run **`npm run styleguide`** to start style a guide dev server.


### PR DESCRIPTION
When following  the original Getting Started Guide, the command I copied from it (`vue-styleguidist build`) causes an  error (#1482 ).

This change in the manual clarifies that for Vue-CLI, the correct command is

```
vue-cli-service styleguidist:build
```