### PR TITLE
fix(vue-docgen-api): Catch error for model if not literal object

### DIFF
--- a/.changeset/issing-model.md
+++ b/.changeset/issing-model.md
@@ -1,0 +1,5 @@
+---
+"vue-docgen-api": patch
+---
+
+fix(vue-docgen-api): Catch error for model if not literal object

--- a/packages/vue-docgen-api/src/script-handlers/propHandler.test.ts
+++ b/packages/vue-docgen-api/src/script-handlers/propHandler.test.ts
@@ -478,11 +478,11 @@ describe('propHandler', () => {
           }
         }
         `
-                        expect(await parserTest(src)).toMatchObject({
-                                description: 'Value of the field'
-                        })
-                        expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('value')
-                        expect(documentation.getPropDescriptor).toHaveBeenCalledWith('v-model')
+			expect(await parserTest(src)).toMatchObject({
+				description: 'Value of the field'
+			})
+			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('value')
+			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('v-model')
 		})
 
 		it('should not set the v-model instead of value if model property has only event', async () => {
@@ -511,10 +511,10 @@ describe('propHandler', () => {
 
 		it('should not set and crash if model is not literal object', async () => {
 			const src = dedent`
-        const getModel = () => ({
-          prop: 'modelValue',
-          event: 'update:modelValue'
-        })
+				const getModel = () => ({
+				  prop: 'modelValue',
+				  event: 'update:modelValue'
+				})
         export default {
           model: getModel(),
           props: {

--- a/packages/vue-docgen-api/src/script-handlers/propHandler.test.ts
+++ b/packages/vue-docgen-api/src/script-handlers/propHandler.test.ts
@@ -508,6 +508,32 @@ describe('propHandler', () => {
 			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('v-model')
 			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('value')
 		})
+
+		it('should not set and crash if model is not literal object', async () => {
+			const src = dedent`
+				const getModel = () => ({
+				  prop: 'modelValue',
+				  event: 'update:modelValue'
+				})
+        export default {
+          model: getModel(),
+          props: {
+            /**
+             * Value of the field
+             */
+            value: {
+              required: true,
+              type: undefined
+            }
+          }
+        }
+        `
+			expect(await parserTest(src)).toMatchObject({
+				description: 'Value of the field'
+			})
+			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('v-model')
+			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('value')
+		})
 	})
 
 	describe('@values tag parsing', () => {

--- a/packages/vue-docgen-api/src/script-handlers/propHandler.test.ts
+++ b/packages/vue-docgen-api/src/script-handlers/propHandler.test.ts
@@ -478,11 +478,11 @@ describe('propHandler', () => {
           }
         }
         `
-			expect(await parserTest(src)).toMatchObject({
-				description: 'Value of the field'
-			})
-			expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('value')
-			expect(documentation.getPropDescriptor).toHaveBeenCalledWith('v-model')
+                        expect(await parserTest(src)).toMatchObject({
+                                description: 'Value of the field'
+                        })
+                        expect(documentation.getPropDescriptor).not.toHaveBeenCalledWith('value')
+                        expect(documentation.getPropDescriptor).toHaveBeenCalledWith('v-model')
 		})
 
 		it('should not set the v-model instead of value if model property has only event', async () => {
@@ -511,10 +511,10 @@ describe('propHandler', () => {
 
 		it('should not set and crash if model is not literal object', async () => {
 			const src = dedent`
-				const getModel = () => ({
-				  prop: 'modelValue',
-				  event: 'update:modelValue'
-				})
+        const getModel = () => ({
+          prop: 'modelValue',
+          event: 'update:modelValue'
+        })
         export default {
           model: getModel(),
           props: {

--- a/packages/vue-docgen-api/src/script-handlers/propHandler.ts
+++ b/packages/vue-docgen-api/src/script-handlers/propHandler.ts
@@ -518,10 +518,17 @@ function getModelPropName(path: NodePath): string | null {
 		return null
 	}
 
-	const modelPropertyNamePath =
+	const modelValue =
 		modelPath.length &&
 		modelPath[0]
 			.get('value')
+
+	if (!bt.isObjectExpression(modelValue.node))  {
+		return null
+	}
+
+	const modelPropertyNamePath =
+		modelValue
 			.get('properties')
 			.filter((p: NodePath) => bt.isObjectProperty(p.node) && getMemberFilter('prop')(p))
 


### PR DESCRIPTION
fix #1481