### PR TITLE
fix(examples/docgen-vite): fix incorrect footer prev/next page display

### DIFF
--- a/examples/docgen-vite/docs/.vitepress/config.mjs
+++ b/examples/docgen-vite/docs/.vitepress/config.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
         items: sidebarComponents.map(comp => {
           return {
             text: comp.replace(/^components\//, '').replace(/\.md$/, ''),
-            link: comp.replace(/\.md$/, '')
+            link: '/' + comp.replace(/\.md$/, '')
           }
         })
       }


### PR DESCRIPTION
Hello @elevatebart,

As you can see in  the [demo link](https://vue-styleguidist.github.io/docgen-vite/), all pages display next page to HelloWolrd without prev page. And it's caused by incorrect vitepress config that lack of `/` in the front of every link.

So I fix this issue.