### PR TITLE
Small perf improvement to path resolution

### DIFF
--- a/.changeset/improve-perf-resolve-path.md
+++ b/.changeset/improve-perf-resolve-path.md
@@ -1,0 +1,5 @@
+---
+'vue-docgen-api': patch
+---
+
+improve performance of the path resolution

--- a/packages/vue-docgen-api/src/utils/resolvePathFrom.ts
+++ b/packages/vue-docgen-api/src/utils/resolvePathFrom.ts
@@ -6,7 +6,7 @@ const SUFFIXES = ['', '.js', '.ts', '.vue', '.jsx', '.tsx']
 export default function resolvePathFrom(path: string, from: string[]): string | null {
 	let finalPath: string | null = null
 
-	SUFFIXES.forEach(s => {
+	for (const s of SUFFIXES) {
 		if (!finalPath) {
 			try {
 				finalPath = require.resolve(`${path}${s}`, {
@@ -37,7 +37,10 @@ export default function resolvePathFrom(path: string, from: string[]): string | 
 				}
 			}
 		}
-	})
+		if (finalPath) {
+			break
+		}
+	}
 
 	try {
 		const packagePath = require.resolve(join(path, 'package.json'), {


### PR DESCRIPTION
This is an improvement I found while looking through the code. Once the path has been resolved with a suffix, it is not necessary to go loop through the others. 