### PR TITLE
Add initial support for external types in defineProps and defineEmits

### DIFF
--- a/.changeset/young-boats-jog.md
+++ b/.changeset/young-boats-jog.md
@@ -1,0 +1,5 @@
+---
+'vue-docgen-api': minor
+---
+
+Add initial support for external types in defineProps and defineEmits

--- a/packages/vue-docgen-api/src/script-setup-handlers/setupEventHandler.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/setupEventHandler.ts
@@ -47,9 +47,9 @@ export default async function setupEventHandler(
 	}
 
 	function readEventsTSTypes(refs: NodePath) {
-    if(!refs.value){
-      return
-    }
+		if (!refs.value) {
+			return
+		}
 		refs.each((member: NodePath) => {
 			if (bt.isTSCallSignatureDeclaration(member.node)) {
 				const firstParam = member.node.parameters[0].typeAnnotation
@@ -57,7 +57,7 @@ export default async function setupEventHandler(
 					bt.isTSTypeAnnotation(firstParam) &&
 					bt.isTSLiteralType(firstParam.typeAnnotation) &&
 					!bt.isUnaryExpression(firstParam.typeAnnotation.literal) &&
-          !bt.isTemplateLiteral(firstParam.typeAnnotation.literal) &&
+					!bt.isTemplateLiteral(firstParam.typeAnnotation.literal) &&
 					typeof firstParam.typeAnnotation.literal.value === 'string'
 				) {
 					buildEventDescriptor(firstParam.typeAnnotation.literal.value, member)
@@ -99,7 +99,8 @@ export default async function setupEventHandler(
 						} else if (bt.isTSTypeReference(param.node) && bt.isIdentifier(param.node.typeName)) {
 							const resolvedType = getTypeDefinitionFromIdentifier(
 								astPath,
-								param.node.typeName.name
+								param.node.typeName.name,
+								opt
 							)
 							if (resolvedType) {
 								readEventsTSTypes(resolvedType)

--- a/packages/vue-docgen-api/src/script-setup-handlers/setupPropHandler.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/setupPropHandler.ts
@@ -44,7 +44,8 @@ export default async function setupPropHandler(
 						// its a reference to an interface or type
 						const typeName = typeParamsPath.node.typeName.name // extract the identifier
 						// find it's definition in the file
-						const definitionPath = getTypeDefinitionFromIdentifier(astPath, typeName)
+
+						const definitionPath = getTypeDefinitionFromIdentifier(astPath, typeName, opt)
 						// use the same process to exact info
 						if (definitionPath) {
 							getPropsFromLiteralType(documentation, definitionPath)

--- a/packages/vue-docgen-api/src/script-setup-handlers/utils/__fixtures__/types.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/utils/__fixtures__/types.ts
@@ -1,0 +1,7 @@
+export type LocalType = {
+	/**
+	 * describe the local prop
+	 */
+	prop1: boolean
+	prop2: string
+}

--- a/packages/vue-docgen-api/src/script-setup-handlers/utils/tsUtils.test.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/utils/tsUtils.test.ts
@@ -1,5 +1,6 @@
 import { getTypeDefinitionFromIdentifier } from './tsUtils'
 import buildParser from '../../babel-parser'
+import { ParseOptions } from '../../types'
 
 describe('getTypeDefinitionFromIdentifier', () => {
 	it('resolves an interface in the global scope', () => {
@@ -15,13 +16,15 @@ describe('getTypeDefinitionFromIdentifier', () => {
 					defineProps<LocalType>()
 					`
 		const astFile = parser.parse(src)
-		//console.log(astFile)
-		const nodePath: any = getTypeDefinitionFromIdentifier(astFile, 'LocalType')
-		const props = nodePath?.map((prop: any) => prop.node.key.name+' '+prop.node.typeAnnotation.typeAnnotation.type); 
-		expect(
-			props
-			).toStrictEqual(["prop1 TSBooleanKeyword","prop2 TSStringKeyword"]);
-	}),
+		const nodePath: any = getTypeDefinitionFromIdentifier(astFile, 'LocalType', {
+			filePath: __filename
+		} as ParseOptions)
+		const props = nodePath?.map(
+			(prop: any) => prop.node.key.name + ' ' + prop.node.typeAnnotation.typeAnnotation.type
+		)
+		expect(props).toStrictEqual(['prop1 TSBooleanKeyword', 'prop2 TSStringKeyword'])
+	})
+
 	it('resolves an Type alias in the global scope', () => {
 		const parser = buildParser({ plugins: ['typescript'] })
 		const src = `
@@ -35,10 +38,29 @@ describe('getTypeDefinitionFromIdentifier', () => {
 					defineProps<LocalType>()
 					`
 		const astFile = parser.parse(src)
-		const nodePath: any = getTypeDefinitionFromIdentifier(astFile, 'LocalType')
-		const props = nodePath?.map((prop: any) => prop.node.key.name+' '+prop.node.typeAnnotation.typeAnnotation.type); 
-		expect(
-			props
-			).toStrictEqual(["prop1 TSBooleanKeyword","prop2 TSStringKeyword"]);
+		const nodePath: any = getTypeDefinitionFromIdentifier(astFile, 'LocalType', {
+			filePath: __filename
+		} as ParseOptions)
+		const props = nodePath?.map(
+			(prop: any) => prop.node.key.name + ' ' + prop.node.typeAnnotation.typeAnnotation.type
+		)
+		expect(props).toStrictEqual(['prop1 TSBooleanKeyword', 'prop2 TSStringKeyword'])
+	})
+
+	it('resolves an Type alias defined in another file', () => {
+		const parser = buildParser({ plugins: ['typescript'] })
+		const src = `
+		import type {LocalType} from './__fixtures__/types.ts';
+			
+		defineProps<LocalType>()
+					`
+		const astFile = parser.parse(src)
+		const nodePath: any = getTypeDefinitionFromIdentifier(astFile, 'LocalType', {
+			filePath: __filename
+		} as ParseOptions)
+		const props = nodePath?.map(
+			(prop: any) => prop.node.key.name + ' ' + prop.node.typeAnnotation.typeAnnotation.type
+		)
+		expect(props).toStrictEqual(['prop1 TSBooleanKeyword', 'prop2 TSStringKeyword'])
 	})
 })

--- a/packages/vue-docgen-api/src/script-setup-handlers/utils/tsUtils.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/utils/tsUtils.ts
@@ -1,16 +1,125 @@
+import fs from 'fs'
 import * as bt from '@babel/types'
 import { NodePath } from 'ast-types/lib/node-path'
+import { TSExpressionWithTypeArgumentsKind, TSPropertySignatureKind } from 'ast-types/lib/gen/kinds'
 import { visit } from 'recast'
+import { dirname } from 'path'
+import buildParser from '../../babel-parser'
+import { ParseOptions } from '../../types'
+import makePathResolver from '../../utils/makePathResolver'
+
+const getTypeDefinitionFromIdentifierFromModule = (
+	module: string,
+	typeName: string,
+	opt: ParseOptions,
+	pathResolver: (filePath: string, originalDirNameOverride?: string) => string | null
+) => {
+	const parser = buildParser({ plugins: ['typescript'] })
+	const filePath = pathResolver(module)
+
+	if (!filePath) {
+		return undefined
+	}
+
+	return getTypeDefinitionFromIdentifier(
+		parser.parse(
+			fs.readFileSync(filePath, {
+				encoding: 'utf-8'
+			})
+		),
+		typeName,
+		{
+			...opt,
+			filePath
+		}
+	)
+}
 
 export function getTypeDefinitionFromIdentifier(
 	astPath: bt.File,
-	typeName: string
+	typeName: string,
+	opt: ParseOptions
 ): NodePath | undefined {
 	let typeBody: NodePath | undefined = undefined
+	const pathResolver = makePathResolver(dirname(opt.filePath), opt.alias, opt.modules)
+
 	visit(astPath.program, {
+		visitExportAllDeclaration(nodePath) {
+			typeBody =
+				typeBody ??
+				getTypeDefinitionFromIdentifierFromModule(
+					nodePath.value.source.value,
+					typeName,
+					opt,
+					pathResolver
+				)
+
+			return false
+		},
+		visitExportSpecifier(nodePath) {
+			if (!typeBody && nodePath.value.exported.name === typeName) {
+				typeBody = getTypeDefinitionFromIdentifierFromModule(
+					nodePath.parent.value.source.value,
+					nodePath.value.local.name,
+					opt,
+					pathResolver
+				)
+			}
+
+			return false
+		},
+		visitImportSpecifier(nodePath) {
+			if (!typeBody && nodePath.value.imported.name === typeName) {
+				typeBody = getTypeDefinitionFromIdentifierFromModule(
+					nodePath.parent.value.source.value,
+					typeName,
+					opt,
+					pathResolver
+				)
+			}
+
+			return false
+		},
 		visitTSInterfaceDeclaration(nodePath) {
 			if (bt.isIdentifier(nodePath.node.id) && nodePath.node.id.name === typeName) {
-				typeBody = nodePath.get('body', 'body')
+				const interfaceBody = nodePath.get('body', 'body')
+
+				if (!interfaceBody) {
+					return
+				}
+
+				// If the interface extends from other interfaces, look these up and insert their properties
+				// into the just resolved interface. If the inheriting interface already has such a property
+				// defined, to not add it, as the inheriting interface overwrites it.
+				if (nodePath.value.extends) {
+					const parentInterfaces = nodePath.value.extends as TSExpressionWithTypeArgumentsKind[]
+					parentInterfaces.forEach(parentInterface => {
+						if (!bt.isIdentifier(parentInterface.expression)) {
+							return
+						}
+
+						const parentInterfaceBody = getTypeDefinitionFromIdentifier(
+							astPath,
+							parentInterface.expression.name,
+							opt
+						)
+
+						parentInterfaceBody?.value.forEach((parentInterfaceProp: TSPropertySignatureKind) => {
+							if (
+								!interfaceBody.value.find(
+									(prop: TSPropertySignatureKind) =>
+										bt.isIdentifier(prop.key) &&
+										bt.isIdentifier(parentInterfaceProp.key) &&
+										prop.key.name === parentInterfaceProp.key.name
+								)
+							) {
+								interfaceBody.value.splice(0, 0, parentInterfaceProp)
+							}
+						})
+					})
+				}
+
+				typeBody = interfaceBody
 			}
 			return false
 		},

--- a/packages/vue-docgen-api/src/utils/makePathResolver.ts
+++ b/packages/vue-docgen-api/src/utils/makePathResolver.ts
@@ -6,6 +6,14 @@ export default function makePathResolver(
 	aliases?: { [alias: string]: string | string[] },
 	modules?: string[]
 ): (filePath: string, originalDirNameOverride?: string) => string | null {
+	/**
+	 * Emulate the module import logic as much as necessary to resolve a module containing the
+	 * interface or type.
+	 *
+	 * @param base Path to the file that is importing the module
+	 * @param module Relative path to the module
+	 * @returns The absolute path to the file that contains the module to be imported
+	 */
 	return (filePath: string, originalDirNameOverride?: string) =>
 		resolvePathFrom(resolveAliases(filePath, aliases || {}, refDirName), [
 			originalDirNameOverride || refDirName,

--- a/packages/vue-docgen-api/tests/components/setup-syntax/ProgressExternalTypes.vue
+++ b/packages/vue-docgen-api/tests/components/setup-syntax/ProgressExternalTypes.vue
@@ -1,0 +1,61 @@
+<template>
+  <svg :height="radius * 2" :width="radius * 2" @click="convertTheThings(1); emit('save', circumference);">
+    <circle stroke="#EBEBEB" fill="transparent" :stroke-width="stroke" :r="normalizedRadius" :cx="radius"
+      :cy="radius" />
+    <circle stroke="currentColor" fill="transparent" :stroke-dasharray="circumference + ' ' + circumference"
+      :style="{ strokeDashoffset }" :stroke-width="stroke" :r="normalizedRadius" :cx="radius" :cy="radius"
+      stroke-linecap="round" />
+  </svg>
+</template>
+
+<script>
+
+function convertTheThings(value) {
+  return value;
+}
+
+export { convertTheThings }
+
+</script>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import type { PropsInterface } from './interfaces';
+
+const emit = defineEmits<{
+  /**
+   * Cancels everything
+   */
+  (event: 'cancel'): void
+  /**
+   * Save the world
+   */
+  (event: 'save', arg: number): void
+}>()
+
+defineExpose([
+  /**
+   * position of the dash offset
+   */
+  'strokeDashoffset'
+])
+
+const props = withDefaults(defineProps<PropsInterface>(),
+  {
+    progress: 0,
+  })
+
+const normalizedRadius = props.radius - props.stroke * 2
+const circumference = normalizedRadius * 2 * Math.PI
+
+const strokeDashoffset = computed(() => {
+  return circumference - props.progress / 100 * circumference
+})
+</script>
+
+<style scoped>
+svg {
+  transform: rotate(-90deg);
+  transform-origin: 50% 50%;
+}
+</style>

--- a/packages/vue-docgen-api/tests/components/setup-syntax/interfaces.ts
+++ b/packages/vue-docgen-api/tests/components/setup-syntax/interfaces.ts
@@ -1,0 +1,26 @@
+interface WithProgress {
+	/**
+	 * The percentage of the circle that is filled.
+	 */
+	progress?: string | number
+}
+
+interface WithStrokeAndProgress extends WithProgress {
+	/**
+	 * The percentage of the circle that is filled.
+	 */
+	progress?: number
+	/**
+	 * The stroke width of the circle.
+	 */
+	stroke: number
+}
+
+interface WithRadius {
+	/**
+	 * The radius of the circle.
+	 */
+	radius: number
+}
+
+export interface PropsInterface extends WithStrokeAndProgress, WithRadius {}

--- a/packages/vue-docgen-api/tests/components/setup-syntax/setup-syntax-external-types.test.ts
+++ b/packages/vue-docgen-api/tests/components/setup-syntax/setup-syntax-external-types.test.ts
@@ -1,0 +1,101 @@
+import * as path from 'path'
+import { ComponentDoc } from '../../../src/Documentation'
+import { parse } from '../../../src/main'
+
+const progressPath = path.join(__dirname, './ProgressExternalTypes.vue')
+let doc: ComponentDoc
+
+describe('setup syntactic sugar with type imports', () => {
+	beforeEach(async () => {
+		doc = await parse(progressPath)
+	})
+
+	describe('props', () => {
+		it('should return a doc object containing props', () => {
+			expect(doc).toHaveProperty('props')
+		})
+
+		it('should find 3 props', () => {
+			expect(doc.props).toHaveLength(3)
+		})
+
+		it('should match the snapshot', () => {
+			expect(doc.props).toMatchInlineSnapshot(`
+				[
+				  {
+				    "description": "The radius of the circle.",
+				    "name": "radius",
+				    "required": true,
+				    "type": {
+				      "name": "number",
+				    },
+				  },
+				  {
+				    "description": "The stroke width of the circle.",
+				    "name": "stroke",
+				    "required": true,
+				    "type": {
+				      "name": "number",
+				    },
+				  },
+				  {
+				    "defaultValue": {
+				      "func": false,
+				      "value": "0",
+				    },
+				    "description": "The percentage of the circle that is filled.",
+				    "name": "progress",
+				    "required": false,
+				    "type": {
+				      "name": "number",
+				    },
+				  },
+				]
+			`)
+		})
+
+		describe('events', () => {
+			it('should return a doc object containing events', () => {
+				expect(doc.events).toHaveLength(2)
+			})
+
+			it('should match the snapshot', () => {
+				expect(doc.events).toMatchInlineSnapshot(`
+					[
+					  {
+					    "description": "Cancels everything",
+					    "name": "cancel",
+					    "type": undefined,
+					  },
+					  {
+					    "description": "Save the world",
+					    "name": "save",
+					    "type": {
+					      "names": [
+					        "number",
+					      ],
+					    },
+					  },
+					]
+				`)
+			})
+		})
+
+		describe('expose', () => {
+			it('should return a doc object containing expose', () => {
+				expect(doc.expose).toHaveLength(1)
+			})
+
+			it('should match the snapshot', () => {
+				expect(doc.expose).toMatchInlineSnapshot(`
+          [
+            {
+              "description": "position of the dash offset",
+              "name": "strokeDashoffset",
+            },
+          ]
+        `)
+			})
+		})
+	})
+})


### PR DESCRIPTION
This PR adds initial support for imported interfaces and types in `defineProps` and `defineEmits`. 

Based on my understanding of the codebase, so I might (as usual :) ) have missed something obvious. I tested the change on a fairly large code base (about 200 components + sub-components) and haven't noticed any performance degradations. 

Known limitations:

* Does not support resolving modules that need additional configuration to make sense (`import type {Props} from '@/interfaces.ts'`)
* Does not support types defined in third-party dependencies / in `node_modules`