### PR TITLE
add support for new defineEmits syntax in Vue 3.3

### DIFF
--- a/.changeset/slimy-poets-retire.md
+++ b/.changeset/slimy-poets-retire.md
@@ -1,0 +1,5 @@
+---
+'vue-docgen-api': minor
+---
+
+Add support for new defineEmits Syntax in Vue 3.3

--- a/packages/vue-docgen-api/src/script-setup-handlers/setupEventHandler.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/setupEventHandler.ts
@@ -25,11 +25,16 @@ export default async function setupEventHandler(
 	function buildEventDescriptor(eventName: string, eventPath: NodePath) {
 		const eventDescriptor = documentation.getEventDescriptor(eventName)
 
-		const typeParam = bt.isTSPropertySignature(eventPath.node)
+		const isPropertyEmitSyntax = bt.isTSPropertySignature(eventPath.node)
+		const typeParam = isPropertyEmitSyntax
 			? eventPath.get('typeAnnotation')
 			: eventPath.get('parameters', 1, 'typeAnnotation')
 		if (bt.isTSTypeAnnotation(typeParam.node)) {
-			const type = getTypeFromAnnotation(typeParam.node)
+			let type = getTypeFromAnnotation(typeParam.node)
+			if (isPropertyEmitSyntax && type) {
+				type = type.elements?.[0]
+			}
+
 			if (type) {
 				eventDescriptor.type = {
 					names: [type.name]

--- a/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/NewEmitSyntax.vue
+++ b/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/NewEmitSyntax.vue
@@ -1,0 +1,36 @@
+<template>
+	<input type="text" :value="modelValue" @input="onInput" />
+</template>
+
+<script lang="ts" setup>
+const emit = defineEmits<{
+	/**
+	 * An event without payload
+	 */
+	eventWithoutPayload: []
+	/**
+	 * An event with payload
+	 */
+	eventWithPayload: [value: boolean]
+	/**
+	 * Event used for v-model
+	 */
+	'update:modelValue': [value: string]
+}>()
+
+const props = defineProps<{
+	/**
+	 * The value of the input
+	 */
+	modelValue: string
+}>()
+
+function onInput(e: Event) {
+	if (
+		e.target &&
+		(e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement)
+	) {
+		emit('update:modelValue', e.target.value)
+	}
+}
+</script>

--- a/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/NewEmitSyntax.vue
+++ b/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/NewEmitSyntax.vue
@@ -4,18 +4,22 @@
 
 <script lang="ts" setup>
 const emit = defineEmits<{
-	/**
-	 * An event without payload
-	 */
-	eventWithoutPayload: []
-	/**
-	 * An event with payload
-	 */
-	eventWithPayload: [value: boolean]
-	/**
-	 * Event used for v-model
-	 */
-	'update:modelValue': [value: string]
+  /**
+   * An event without payload
+   */
+  eventWithoutPayload: []
+  /**
+   * An event with named tuple as payload
+   */
+  eventWithNamedPayload: [value: [boolean, string], secondValue: number]
+  /**
+   * An event with unnamed tuple as payload
+   */
+  eventWithUnnamedPayload: [number, boolean]
+  /**
+   * Event used for v-model
+   */
+  'update:modelValue': [value: string]
 }>()
 
 const props = defineProps<{

--- a/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/NewEmitSyntaxSeparateType.vue
+++ b/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/NewEmitSyntaxSeparateType.vue
@@ -4,18 +4,22 @@
 
 <script lang="ts" setup>
 type Emits = {
-	/**
-	 * An event without payload
-	 */
-	eventWithoutPayload: []
-	/**
-	 * An event with payload
-	 */
-	eventWithPayload: [value: boolean]
-	/**
-	 * Event used for v-model
-	 */
-	'update:modelValue': [value: string]
+  /**
+   * An event without payload
+   */
+  eventWithoutPayload: []
+  /**
+   * An event with named tuple as payload
+   */
+  eventWithNamedPayload: [value: [boolean, string], secondValue: number]
+  /**
+   * An event with unnamed tuple as payload
+   */
+  eventWithUnnamedPayload: [number, boolean]
+  /**
+   * Event used for v-model
+   */
+  'update:modelValue': [value: string]
 }
 const emit = defineEmits<Emits>()
 

--- a/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/NewEmitSyntaxSeparateType.vue
+++ b/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/NewEmitSyntaxSeparateType.vue
@@ -1,0 +1,38 @@
+<template>
+	<input type="text" :value="modelValue" @input="onInput" />
+</template>
+
+<script lang="ts" setup>
+type Emits = {
+	/**
+	 * An event without payload
+	 */
+	eventWithoutPayload: []
+	/**
+	 * An event with payload
+	 */
+	eventWithPayload: [value: boolean]
+	/**
+	 * Event used for v-model
+	 */
+	'update:modelValue': [value: string]
+}
+const emit = defineEmits<Emits>()
+
+type Props = {
+	/**
+	 * The value of the input
+	 */
+	modelValue: string
+}
+const props = defineProps<Props>()
+
+function onInput(e: Event) {
+	if (
+		e.target &&
+		(e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement)
+	) {
+		emit('update:modelValue', e.target.value)
+	}
+}
+</script>

--- a/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/setup-new-emit-syntax.test.ts
+++ b/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/setup-new-emit-syntax.test.ts
@@ -35,41 +35,54 @@ describe.each(['./NewEmitSyntax.vue', './NewEmitSyntaxSeparateType.vue'])(
 
 		describe('events', () => {
 			it('should return a doc object containing events', () => {
-				expect(doc.events).toHaveLength(3)
+				expect(doc.events).toHaveLength(4)
 			})
 
 			it('should match the snapshot', () => {
 				expect(doc.events).toMatchInlineSnapshot(`
-				[
-				  {
-				    "description": "An event without payload",
-				    "name": "eventWithoutPayload",
-				    "type": {
-				      "names": [
-				        "TSTupleType",
-				      ],
-				    },
-				  },
-				  {
-				    "description": "An event with payload",
-				    "name": "eventWithPayload",
-				    "type": {
-				      "names": [
-				        "TSTupleType",
-				      ],
-				    },
-				  },
-				  {
-				    "description": "Event used for v-model",
-				    "name": "update:modelValue",
-				    "type": {
-				      "names": [
-				        "TSTupleType",
-				      ],
-				    },
-				  },
-				]
-			`)
+					[
+					  {
+					    "description": "An event without payload",
+					    "name": "eventWithoutPayload",
+					    "type": undefined,
+					  },
+					  {
+					    "description": "An event with named tuple as payload",
+					    "name": "eventWithNamedPayload",
+					    "type": {
+					      "elements": [
+					        {
+					          "name": "boolean",
+					        },
+					        {
+					          "name": "string",
+					        },
+					      ],
+					      "names": [
+					        "tuple",
+					      ],
+					    },
+					  },
+					  {
+					    "description": "An event with unnamed tuple as payload",
+					    "name": "eventWithUnnamedPayload",
+					    "type": {
+					      "names": [
+					        "number",
+					      ],
+					    },
+					  },
+					  {
+					    "description": "Event used for v-model",
+					    "name": "update:modelValue",
+					    "type": {
+					      "names": [
+					        "string",
+					      ],
+					    },
+					  },
+					]
+				`)
 			})
 		})
 	}

--- a/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/setup-new-emit-syntax.test.ts
+++ b/packages/vue-docgen-api/tests/components/setup-new-emit-syntax/setup-new-emit-syntax.test.ts
@@ -1,0 +1,76 @@
+import * as path from 'path'
+import { ComponentDoc } from '../../../src/Documentation'
+import { parse } from '../../../src/main'
+
+let doc: ComponentDoc
+
+describe.each(['./NewEmitSyntax.vue', './NewEmitSyntaxSeparateType.vue'])(
+	'setup new defineEmits syntax from Vue 3.3 for file %s',
+	fileName => {
+		beforeEach(async () => {
+			const filePath = path.join(__dirname, fileName)
+			doc = await parse(filePath)
+		})
+
+		describe('props', () => {
+			it('should find 3 props', () => {
+				expect(doc.props).toHaveLength(1)
+			})
+
+			it('should match the snapshot', () => {
+				expect(doc.props).toMatchInlineSnapshot(`
+				[
+				  {
+				    "description": "The value of the input",
+				    "name": "modelValue",
+				    "required": true,
+				    "type": {
+				      "name": "string",
+				    },
+				  },
+				]
+			`)
+			})
+		})
+
+		describe('events', () => {
+			it('should return a doc object containing events', () => {
+				expect(doc.events).toHaveLength(3)
+			})
+
+			it('should match the snapshot', () => {
+				expect(doc.events).toMatchInlineSnapshot(`
+				[
+				  {
+				    "description": "An event without payload",
+				    "name": "eventWithoutPayload",
+				    "type": {
+				      "names": [
+				        "TSTupleType",
+				      ],
+				    },
+				  },
+				  {
+				    "description": "An event with payload",
+				    "name": "eventWithPayload",
+				    "type": {
+				      "names": [
+				        "TSTupleType",
+				      ],
+				    },
+				  },
+				  {
+				    "description": "Event used for v-model",
+				    "name": "update:modelValue",
+				    "type": {
+				      "names": [
+				        "TSTupleType",
+				      ],
+				    },
+				  },
+				]
+			`)
+			})
+		})
+	}
+)

--- a/packages/vue-docgen-api/tests/components/setup-syntax/Progress.vue
+++ b/packages/vue-docgen-api/tests/components/setup-syntax/Progress.vue
@@ -30,6 +30,10 @@ const emit = defineEmits<{
    * Save the world
    */
   (event: 'save', arg: number): void
+	/**
+	 * Event with tuple payload as first arg
+	 */
+	(event: 'eventWithTuplePayload', arg: [number, string]): void
 }>()
 
 defineExpose([

--- a/packages/vue-docgen-api/tests/components/setup-syntax/setup-syntax.test.ts
+++ b/packages/vue-docgen-api/tests/components/setup-syntax/setup-syntax.test.ts
@@ -56,7 +56,7 @@ describe('setup syntactic sugar', () => {
 
 		describe('events', () => {
 			it('should return a doc object containing events', () => {
-				expect(doc.events).toHaveLength(2)
+				expect(doc.events).toHaveLength(3)
 			})
 
 			it('should match the snapshot', () => {
@@ -73,6 +73,23 @@ describe('setup syntactic sugar', () => {
 					    "type": {
 					      "names": [
 					        "number",
+					      ],
+					    },
+					  },
+					  {
+					    "description": "Event with tuple payload as first arg",
+					    "name": "eventWithTuplePayload",
+					    "type": {
+					      "elements": [
+					        {
+					          "name": "number",
+					        },
+					        {
+					          "name": "string",
+					        },
+					      ],
+					      "names": [
+					        "tuple",
 					      ],
 					    },
 					  },


### PR DESCRIPTION
Vue 3.3 added support for a new syntax when using `defineEmits()` in a `<script setup>` tag.

Instead of using call signartures like this:

```ts
defineEmits<{
  (e: input, value: string): void,
}>()
```

a property based type like this can be used:

```ts
defineEmits<{
  input: [value: string],
}>()
```

`vue-docgen-api` did not yet recognize this new possible syntax, so all events from the script tag were missing from the generated result.