### PR TITLE
fix(docs): Wrong regular expression in documentation

### DIFF
--- a/.changeset/cute-clocks-smoke.md
+++ b/.changeset/cute-clocks-smoke.md
@@ -1,0 +1,5 @@
+---
+'vue-docgen-cli': patch
+---
+
+The pattern used in the documentation for explaining the function getDestFile had a little error due to an additional backslash. This update corrects it, which means the documentation will now guide users more accurately on how to use this function.

--- a/packages/vue-docgen-cli/README.md
+++ b/packages/vue-docgen-cli/README.md
@@ -181,7 +181,7 @@ By default it will find the `Readme.md` sibling to the component files. Use this
 
 #### getDestFile
 
-> type: `(file: string, config: DocgenCLIConfig) => string`, default: `(file, config) => path.resolve(config.outDir, file).replace(/\.\w+\$/, '.md')`
+> type: `(file: string, config: DocgenCLIConfig) => string`, default: `(file, config) => path.resolve(config.outDir, file).replace(/\.\w+$/, '.md')`
 
 Function returning the absolute path of the documentation markdown files. If [outFile](#outfile) is used, this config will be ignored.
 


### PR DESCRIPTION

**File path**:  package/vue-doc-cli/README.md

**Description**:  A part of the description of  `getDestFile` is : 

 ` default: (file, config) => path.resolve(config.outDir, file).replace(/\.\w+/$/, '.md')`

 the express `.replace(/\.\w+/$/, '.md')` is supposed to realce the filename extension from `.vue`, `.jsx` ... to `.md`, but it was wrong spelled,  the right one is in follow content:

`default: (file, config) => path.resolve(config.outDir, file).replace(/\.\w+$/, '.md')`
