### PR TITLE
fix(vue-docgen-api): set displayName within setupOptionsHandler

### DIFF
--- a/packages/vue-docgen-api/src/script-setup-handlers/setupOptionsHandler.test.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/setupOptionsHandler.test.ts
@@ -38,6 +38,7 @@ describe('setupOptionsHandler', () => {
         `
 		await parserTest(src)
 		expect(documentation.get('name')).toEqual('testName')
+		expect(documentation.get('displayName')).toEqual('testName')
 	})
 
 	it('should resolve info from the jsdoc of defineOptions', async () => {

--- a/packages/vue-docgen-api/src/script-setup-handlers/setupOptionsHandler.ts
+++ b/packages/vue-docgen-api/src/script-setup-handlers/setupOptionsHandler.ts
@@ -31,6 +31,7 @@ export default async function setupOptionsHandler(
 						const key = property.key.name
 						if (key === 'name' && property.value.type === 'StringLiteral') {
 							documentation.set('name', property.value.value)
+							documentation.set('displayName', property.value.value)
 						}
 					}
 				})


### PR DESCRIPTION
Hi :wave: this PR fix an [issue ](github.com/storybookjs/storybook/issues/30455)in storybook. 

When an SFC with a `<scritp setup>` uses `defineOptions` to set the component's name, `vue-docgen-api` doesn't set the displayName.

`./Button.vue`
```html
<script setup>
defineOptions({
  name: 'SomeOtherName',
});
</script>
```

would result in `{ displayName: 'Button' }` instead of `{ name: 'SomeOtherName' }`. 

This bug doesn't exists when using the old option API.

```ts
<script>
export default {
  name: 'SomeOtherName',
};
</script>
```

related to https://github.com/storybookjs/storybook/pull/33428