### PR TITLE
fix(vue-docgen-cli): escape pipe characters in the method return table

### DIFF
--- a/.changeset/curly-melons-attend.md
+++ b/.changeset/curly-melons-attend.md
@@ -1,0 +1,7 @@
+---
+"vue-docgen-cli": patch
+---
+
+fix: escape pipe characters in the method return table
+
+The Return table in the methods template printed the type and description verbatim, while the Params table escapes them through `mdclean`. A union return type such as `string | number` injected an extra cell into the row, so the markdown no longer matched the two-column header and the description was dropped when rendered.

--- a/packages/vue-docgen-cli/src/templates/methods.spec.ts
+++ b/packages/vue-docgen-cli/src/templates/methods.spec.ts
@@ -1,0 +1,27 @@
+import methods from './methods'
+
+describe('methods', () => {
+	it('escapes pipe characters in the return type and description', () => {
+		const md = methods([
+			{
+				name: 'resolve',
+				description: '',
+				returns: { type: { name: 'string | number' }, description: 'a | b' }
+			}
+		] as any)
+		// The params table escapes pipes through mdclean; the return table must do the same,
+		// otherwise a union type splits the row into extra cells and the table loses data.
+		expect(md).toContain('| string \\| number | a \\| b |')
+	})
+
+	it('escapes pipe characters in the params table', () => {
+		const md = methods([
+			{
+				name: 'resolve',
+				description: '',
+				params: [{ name: 'value', type: { name: 'string | number' }, description: '' }]
+			}
+		] as any)
+		expect(md).toContain('| value | string \\| number |')
+	})
+})

--- a/packages/vue-docgen-cli/src/templates/methods.ts
+++ b/packages/vue-docgen-cli/src/templates/methods.ts
@@ -31,7 +31,7 @@ ${subComponent ? '#' : ''}#### Return
 
   | Type        | Description  |
   | ------------- | -------------|
-  | ${t} | ${d} |
+  | ${mdclean(t)} | ${mdclean(d)} |
   `
 }
 


### PR DESCRIPTION
The Return table in the methods template prints the type and description verbatim:

```
| Type        | Description  |
| ------------- | -------------|
| ${t} | ${d} |
```

Every other table cell in this package is run through `mdclean` first, including the Params table a few lines above it in the same file: `| ${mdclean(n)} | ${mdclean(t)} | ${mdclean(d)} |`. `mdclean` turns a `|` into `\|`.

When a method documents a union return type such as `string | number`, the raw pipe lands in the row and it no longer matches the two column header:

```
| Type        | Description  |
| ------------- | -------------|
| string | number | the resolved value |
```

The header has two columns but the row now has three cells. Per the GFM tables spec the extra cell is dropped, so rendered through marked the type shows as `string`, the description column shows `number`, and the real description `the resolved value` is lost.

The fix routes both values through `mdclean`, the same helper the Params table already uses:

```
| string \| number | the resolved value |
```

which parses back to `string | number` and `the resolved value`.

I added a test in `methods.spec.ts` for the return table and the params table. Reverting the one line change makes the return-table test fail. A changeset is included.
